### PR TITLE
Add admin panel with product and order management

### DIFF
--- a/Tasks/TASK_8_admin-panel.MD
+++ b/Tasks/TASK_8_admin-panel.MD
@@ -1,0 +1,14 @@
+# TASK_8_admin-panel
+
+## Что было сделано
+Настроен административный интерфейс управления товарами и заказами, включая таблицы со списками и формы редактирования. Добавлены API-методы для работы с заказами и статусами на бэкенде, а также новые REST-клиенты на фронтенде.
+
+## Изменения
+- backend/src/modules/orders/ — модуль заказов с DTO, сервисом и контроллером.
+- backend/src/modules/order-statuses/ — модуль справочника статусов заказов.
+- frontend/src/pages/AdminPage.vue и связанные API/компоненты.
+- frontend/src/router/index.ts, frontend/src/components/AppNavbar.vue — маршрут и ссылка на админ-панель.
+
+## Проверка
+- npm run start:dev (backend)
+- npm run dev -- --host 0.0.0.0 --port 5173 (frontend)

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,8 @@ import { UsersModule } from './modules/users/users.module';
 import { CategoriesModule } from './modules/categories/categories.module';
 import { ProductsModule } from './modules/products/products.module';
 import { SizesModule } from './modules/sizes/sizes.module';
+import { OrdersModule } from './modules/orders/orders.module';
+import { OrderStatusesModule } from './modules/order-statuses/order-statuses.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { buildTypeOrmOptions } from './config/typeorm.config';
@@ -23,6 +25,8 @@ import { buildTypeOrmOptions } from './config/typeorm.config';
     CategoriesModule,
     ProductsModule,
     SizesModule,
+    OrdersModule,
+    OrderStatusesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/order-statuses/dto/order-status-response.dto.ts
+++ b/backend/src/modules/order-statuses/dto/order-status-response.dto.ts
@@ -1,0 +1,5 @@
+// dto describing order status lookup entry
+export class OrderStatusResponseDto {
+  id: number;
+  name: string;
+}

--- a/backend/src/modules/order-statuses/order-statuses.controller.ts
+++ b/backend/src/modules/order-statuses/order-statuses.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { OrderStatusesService } from './order-statuses.service';
+import { OrderStatusResponseDto } from './dto/order-status-response.dto';
+
+// controller exposing read-only endpoints for order statuses
+@Controller('order-statuses')
+export class OrderStatusesController {
+  constructor(private readonly orderStatusesService: OrderStatusesService) {}
+
+  @Get()
+  findAll(): Promise<OrderStatusResponseDto[]> {
+    return this.orderStatusesService.findAll();
+  }
+}

--- a/backend/src/modules/order-statuses/order-statuses.module.ts
+++ b/backend/src/modules/order-statuses/order-statuses.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OrderStatus } from './entities/order-status.entity';
+import { OrderStatusesService } from './order-statuses.service';
+import { OrderStatusesController } from './order-statuses.controller';
+
+// module bundling order status infrastructure
+@Module({
+  imports: [TypeOrmModule.forFeature([OrderStatus])],
+  controllers: [OrderStatusesController],
+  providers: [OrderStatusesService],
+  exports: [OrderStatusesService],
+})
+export class OrderStatusesModule {}

--- a/backend/src/modules/order-statuses/order-statuses.service.ts
+++ b/backend/src/modules/order-statuses/order-statuses.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OrderStatus } from './entities/order-status.entity';
+import { OrderStatusResponseDto } from './dto/order-status-response.dto';
+
+// service exposing read operations for order statuses
+@Injectable()
+export class OrderStatusesService {
+  constructor(
+    @InjectRepository(OrderStatus)
+    private readonly statusesRepository: Repository<OrderStatus>,
+  ) {}
+
+  async findAll(): Promise<OrderStatusResponseDto[]> {
+    const statuses = await this.statusesRepository.find({ order: { id: 'ASC' } });
+
+    return statuses.map((status) => ({
+      id: status.id,
+      name: status.name,
+    }));
+  }
+}

--- a/backend/src/modules/orders/dto/order-item-response.dto.ts
+++ b/backend/src/modules/orders/dto/order-item-response.dto.ts
@@ -1,0 +1,11 @@
+// dto describing order item for admin view
+export class OrderItemResponseDto {
+  id: number;
+  product: {
+    id: number;
+    title: string;
+    sku: string;
+  };
+  quantity: number;
+  unitPrice: number;
+}

--- a/backend/src/modules/orders/dto/order-response.dto.ts
+++ b/backend/src/modules/orders/dto/order-response.dto.ts
@@ -1,0 +1,29 @@
+import { OrderItemResponseDto } from './order-item-response.dto';
+
+// dto describing order details for admin responses
+export class OrderResponseDto {
+  id: number;
+  customer: {
+    id: number;
+    name: string;
+    email: string;
+  };
+  status: {
+    id: number;
+    name: string;
+  };
+  totalAmount: number;
+  paymentMethod: string | null;
+  comment: string | null;
+  address: {
+    id: number;
+    city: string;
+    street: string;
+    postalCode: string;
+    comment: string | null;
+  } | null;
+  items: OrderItemResponseDto[];
+  placedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/modules/orders/dto/update-order.dto.ts
+++ b/backend/src/modules/orders/dto/update-order.dto.ts
@@ -1,0 +1,30 @@
+import {
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+// dto for updating order attributes in admin panel
+export class UpdateOrderDto {
+  @IsOptional()
+  @IsInt({ message: 'Статус заказа должен быть указан как число' })
+  statusId?: number;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Сумма заказа должна быть числом' })
+  @IsPositive({ message: 'Сумма заказа должна быть больше нуля' })
+  totalAmount?: number;
+
+  @IsOptional()
+  @IsString({ message: 'Способ оплаты должен быть строкой' })
+  @MaxLength(100, { message: 'Название способа оплаты должно содержать не более 100 символов' })
+  paymentMethod?: string;
+
+  @IsOptional()
+  @IsString({ message: 'Комментарий должен быть строкой' })
+  @MaxLength(1000, { message: 'Комментарий должен содержать не более 1000 символов' })
+  comment?: string;
+}

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Put } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { OrderResponseDto } from './dto/order-response.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+// controller providing admin CRUD for orders
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  findAll(): Promise<OrderResponseDto[]> {
+    return this.ordersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<OrderResponseDto> {
+    return this.ordersService.findById(id);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateOrderDto: UpdateOrderDto,
+  ): Promise<OrderResponseDto> {
+    return this.ordersService.update(id, updateOrderDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.ordersService.remove(id);
+  }
+}

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from './entities/order.entity';
+import { OrdersService } from './orders.service';
+import { OrdersController } from './orders.controller';
+import { OrderStatus } from '../order-statuses/entities/order-status.entity';
+
+// module wiring for order management
+@Module({
+  imports: [TypeOrmModule.forFeature([Order, OrderStatus])],
+  controllers: [OrdersController],
+  providers: [OrdersService],
+  exports: [OrdersService],
+})
+export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Order } from './entities/order.entity';
+import { OrderResponseDto } from './dto/order-response.dto';
+import { OrderItemResponseDto } from './dto/order-item-response.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+import { OrderStatus } from '../order-statuses/entities/order-status.entity';
+
+// service handling admin order management logic
+@Injectable()
+export class OrdersService {
+  constructor(
+    @InjectRepository(Order)
+    private readonly ordersRepository: Repository<Order>,
+    @InjectRepository(OrderStatus)
+    private readonly statusesRepository: Repository<OrderStatus>,
+  ) {}
+
+  async findAll(): Promise<OrderResponseDto[]> {
+    const orders = await this.ordersRepository.find({
+      relations: {
+        user: true,
+        status: true,
+        address: true,
+        items: { product: true },
+      },
+      order: { id: 'ASC' },
+    });
+
+    return orders.map((order) => this.toOrderResponse(order));
+  }
+
+  async findById(id: number): Promise<OrderResponseDto> {
+    const order = await this.ordersRepository.findOne({
+      where: { id },
+      relations: {
+        user: true,
+        status: true,
+        address: true,
+        items: { product: true },
+      },
+    });
+
+    if (!order) {
+      throw new NotFoundException('Заказ не найден');
+    }
+
+    return this.toOrderResponse(order);
+  }
+
+  async update(id: number, updateOrderDto: UpdateOrderDto): Promise<OrderResponseDto> {
+    const order = await this.ordersRepository.findOne({
+      where: { id },
+      relations: {
+        status: true,
+      },
+    });
+
+    if (!order) {
+      throw new NotFoundException('Заказ не найден');
+    }
+
+    if (updateOrderDto.statusId !== undefined) {
+      if (!order.status || order.status.id !== updateOrderDto.statusId) {
+        order.status = await this.findStatusById(updateOrderDto.statusId);
+      }
+    }
+
+    if (updateOrderDto.totalAmount !== undefined) {
+      order.totalAmount = updateOrderDto.totalAmount.toFixed(2);
+    }
+
+    if (updateOrderDto.paymentMethod !== undefined) {
+      const paymentMethod = updateOrderDto.paymentMethod.trim();
+      order.paymentMethod = paymentMethod.length ? paymentMethod : null;
+    }
+
+    if (updateOrderDto.comment !== undefined) {
+      const comment = updateOrderDto.comment.trim();
+      order.comment = comment.length ? comment : null;
+    }
+
+    await this.ordersRepository.save(order);
+
+    return this.findById(order.id);
+  }
+
+  async remove(id: number): Promise<void> {
+    const order = await this.ordersRepository.findOne({ where: { id } });
+
+    if (!order) {
+      throw new NotFoundException('Заказ не найден');
+    }
+
+    await this.ordersRepository.remove(order);
+  }
+
+  private async findStatusById(id: number): Promise<OrderStatus> {
+    const status = await this.statusesRepository.findOne({ where: { id } });
+
+    if (!status) {
+      throw new NotFoundException('Статус заказа не найден');
+    }
+
+    return status;
+  }
+
+  private toOrderResponse(order: Order): OrderResponseDto {
+    const items: OrderItemResponseDto[] = (order.items ?? []).map((item) => ({
+      id: item.id,
+      product: {
+        id: item.product?.id ?? 0,
+        title: item.product?.title ?? 'Товар удален',
+        sku: item.product?.sku ?? '—',
+      },
+      quantity: item.quantity,
+      unitPrice: Number(item.unitPrice),
+    }));
+
+    return {
+      id: order.id,
+      customer: {
+        id: order.user?.id ?? 0,
+        name: order.user?.name ?? 'Неизвестный покупатель',
+        email: order.user?.email ?? '—',
+      },
+      status: {
+        id: order.status?.id ?? 0,
+        name: order.status?.name ?? 'Без статуса',
+      },
+      totalAmount: Number(order.totalAmount),
+      paymentMethod: order.paymentMethod ?? null,
+      comment: order.comment ?? null,
+      address: order.address
+        ? {
+            id: order.address.id,
+            city: order.address.city,
+            street: order.address.street,
+            postalCode: order.address.postalCode,
+            comment: order.address.comment ?? null,
+          }
+        : null,
+      items,
+      placedAt: order.placedAt,
+      createdAt: order.createdAt,
+      updatedAt: order.updatedAt,
+    };
+  }
+}

--- a/frontend/src/api/categories.ts
+++ b/frontend/src/api/categories.ts
@@ -1,0 +1,14 @@
+import { http } from './http';
+
+export interface CategoryDto {
+  id: number;
+  name: string;
+}
+
+export const fetchCategories = async (): Promise<CategoryDto[]> => {
+  const { data } = await http.get<CategoryDto[]>('/categories');
+  return data.map((category) => ({
+    id: category.id,
+    name: category.name,
+  }));
+};

--- a/frontend/src/api/orders.ts
+++ b/frontend/src/api/orders.ts
@@ -1,0 +1,73 @@
+import { http } from './http';
+
+export interface OrderItemDto {
+  id: number;
+  product: {
+    id: number;
+    title: string;
+    sku: string;
+  };
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface OrderDto {
+  id: number;
+  customer: {
+    id: number;
+    name: string;
+    email: string;
+  };
+  status: {
+    id: number;
+    name: string;
+  };
+  totalAmount: number;
+  paymentMethod: string | null;
+  comment: string | null;
+  address: {
+    id: number;
+    city: string;
+    street: string;
+    postalCode: string;
+    comment: string | null;
+  } | null;
+  items: OrderItemDto[];
+  placedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrderStatusDto {
+  id: number;
+  name: string;
+}
+
+export interface UpdateOrderPayload {
+  statusId?: number;
+  totalAmount?: number;
+  paymentMethod?: string;
+  comment?: string;
+}
+
+export const fetchOrders = async (): Promise<OrderDto[]> => {
+  const { data } = await http.get<OrderDto[]>('/orders');
+  return data;
+};
+
+export const fetchOrderStatuses = async (): Promise<OrderStatusDto[]> => {
+  const { data } = await http.get<OrderStatusDto[]>('/order-statuses');
+  return data;
+};
+
+export const updateOrder = async (
+  id: number,
+  payload: UpdateOrderPayload,
+): Promise<OrderDto> => {
+  const { data } = await http.put<OrderDto>(`/orders/${id}`, payload);
+  return data;
+};
+
+export const deleteOrder = async (id: number): Promise<void> => {
+  await http.delete(`/orders/${id}`);
+};

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -33,3 +33,26 @@ export const fetchProductById = async (id: number): Promise<ProductDto> => {
   const { data } = await http.get<ProductDto>(`/products/${id}`);
   return data;
 };
+
+export interface UpdateProductPayload {
+  title?: string;
+  description?: string;
+  price?: number;
+  sku?: string;
+  stockCount?: number;
+  imageUrl?: string;
+  categoryId?: number;
+  sizeId?: number | null;
+}
+
+export const updateProduct = async (
+  id: number,
+  payload: UpdateProductPayload,
+): Promise<ProductDto> => {
+  const { data } = await http.put<ProductDto>(`/products/${id}`, payload);
+  return data;
+};
+
+export const deleteProduct = async (id: number): Promise<void> => {
+  await http.delete(`/products/${id}`);
+};

--- a/frontend/src/api/sizes.ts
+++ b/frontend/src/api/sizes.ts
@@ -1,0 +1,11 @@
+import { http } from './http';
+
+export interface SizeDto {
+  id: number;
+  name: string;
+}
+
+export const fetchSizes = async (): Promise<SizeDto[]> => {
+  const { data } = await http.get<SizeDto[]>('/sizes');
+  return data;
+};

--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -24,6 +24,9 @@
           <li class="nav-item">
             <RouterLink class="nav-link" to="/profile">Профиль</RouterLink>
           </li>
+          <li class="nav-item">
+            <RouterLink class="nav-link" to="/admin">Админ-панель</RouterLink>
+          </li>
         </ul>
         <RouterLink class="btn btn-outline-light" to="/auth">Войти</RouterLink>
       </div>

--- a/frontend/src/pages/AdminPage.vue
+++ b/frontend/src/pages/AdminPage.vue
@@ -1,0 +1,557 @@
+<template>
+  <div>
+    <section class="bg-dark text-white py-4 mb-4">
+      <div class="container">
+        <h1 class="h2 mb-1">Административная панель</h1>
+        <p class="mb-0">Управляйте товарами и заказами магазина</p>
+      </div>
+    </section>
+
+    <section class="container pb-5">
+      <div v-if="globalError" class="alert alert-danger" role="alert">
+        {{ globalError }}
+      </div>
+      <div v-if="successMessage" class="alert alert-success" role="alert">
+        {{ successMessage }}
+      </div>
+
+      <LoadingSpinner v-if="initialLoading" />
+      <div v-else class="row g-4">
+        <div class="col-12">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="h4 mb-0">Товары</h2>
+            <button class="btn btn-outline-secondary" @click="refreshProducts" :disabled="productsLoading">
+              Обновить список
+            </button>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-striped align-middle">
+              <thead class="table-dark">
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Название</th>
+                  <th scope="col">Артикул</th>
+                  <th scope="col">Цена</th>
+                  <th scope="col">Остаток</th>
+                  <th scope="col">Категория</th>
+                  <th scope="col">Размер</th>
+                  <th scope="col" class="text-end">Действия</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="product in products" :key="product.id">
+                  <th scope="row">{{ product.id }}</th>
+                  <td>{{ product.title }}</td>
+                  <td>{{ product.sku }}</td>
+                  <td>{{ formatCurrency(product.price) }}</td>
+                  <td>{{ product.stockCount }}</td>
+                  <td>{{ product.category ? product.category.name : '—' }}</td>
+                  <td>{{ product.size ? product.size.name : '—' }}</td>
+                  <td class="text-end">
+                    <button class="btn btn-sm btn-outline-primary me-2" @click="startEditProduct(product)">
+                      Редактировать
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" @click="removeProduct(product)">
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="!products.length">
+                  <td colspan="8" class="text-center text-muted py-4">Товары не найдены</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div v-if="productForm" class="card border-dark mt-4">
+            <div class="card-header bg-dark text-white">Редактирование товара #{{ productForm.id }}</div>
+            <div class="card-body">
+              <form @submit.prevent="saveProduct">
+                <div class="row g-3">
+                  <div class="col-md-6">
+                    <label class="form-label" for="productTitle">Название</label>
+                    <input
+                      id="productTitle"
+                      v-model="productForm.title"
+                      type="text"
+                      class="form-control"
+                      placeholder="Введите название"
+                      required
+                    />
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label" for="productSku">Артикул</label>
+                    <input
+                      id="productSku"
+                      v-model="productForm.sku"
+                      type="text"
+                      class="form-control"
+                      placeholder="Артикул"
+                      required
+                    />
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label" for="productPrice">Цена (₽)</label>
+                    <input
+                      id="productPrice"
+                      v-model="productForm.price"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      class="form-control"
+                      required
+                    />
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label" for="productStock">Остаток</label>
+                    <input
+                      id="productStock"
+                      v-model="productForm.stockCount"
+                      type="number"
+                      min="0"
+                      class="form-control"
+                      required
+                    />
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label" for="productCategory">Категория</label>
+                    <select id="productCategory" v-model="productForm.categoryId" class="form-select" required>
+                      <option value="">Выберите категорию</option>
+                      <option v-for="category in categories" :key="category.id" :value="String(category.id)">
+                        {{ category.name }}
+                      </option>
+                    </select>
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label" for="productSize">Размер</label>
+                    <select id="productSize" v-model="productForm.sizeId" class="form-select">
+                      <option value="">Без размера</option>
+                      <option v-for="size in sizes" :key="size.id" :value="String(size.id)">
+                        {{ size.name }}
+                      </option>
+                    </select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label" for="productImage">Ссылка на изображение</label>
+                    <input
+                      id="productImage"
+                      v-model="productForm.imageUrl"
+                      type="url"
+                      class="form-control"
+                      placeholder="https://"
+                    />
+                  </div>
+                  <div class="col-12">
+                    <label class="form-label" for="productDescription">Описание</label>
+                    <textarea
+                      id="productDescription"
+                      v-model="productForm.description"
+                      class="form-control"
+                      rows="3"
+                      placeholder="Короткое описание товара"
+                    ></textarea>
+                  </div>
+                </div>
+                <div class="d-flex justify-content-between align-items-center mt-4">
+                  <button class="btn btn-primary" type="submit" :disabled="productSaving">
+                    Сохранить изменения
+                  </button>
+                  <button class="btn btn-outline-secondary" type="button" @click="cancelProductEdit" :disabled="productSaving">
+                    Отменить
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-12">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="h4 mb-0">Заказы</h2>
+            <button class="btn btn-outline-secondary" @click="refreshOrders" :disabled="ordersLoading">
+              Обновить список
+            </button>
+          </div>
+          <div class="table-responsive">
+            <table class="table table-striped align-middle">
+              <thead class="table-dark">
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Покупатель</th>
+                  <th scope="col">Статус</th>
+                  <th scope="col">Сумма</th>
+                  <th scope="col">Способ оплаты</th>
+                  <th scope="col">Позиций</th>
+                  <th scope="col">Обновлен</th>
+                  <th scope="col" class="text-end">Действия</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="order in orders" :key="order.id">
+                  <th scope="row">{{ order.id }}</th>
+                  <td>
+                    <div class="fw-semibold">{{ order.customer.name }}</div>
+                    <div class="text-muted small">{{ order.customer.email }}</div>
+                  </td>
+                  <td>{{ order.status.name }}</td>
+                  <td>{{ formatCurrency(order.totalAmount) }}</td>
+                  <td>{{ order.paymentMethod || '—' }}</td>
+                  <td>{{ order.items.length }}</td>
+                  <td>{{ formatDate(order.updatedAt) }}</td>
+                  <td class="text-end">
+                    <button class="btn btn-sm btn-outline-primary me-2" @click="startEditOrder(order)">
+                      Редактировать
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" @click="removeOrder(order)">
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="!orders.length">
+                  <td colspan="8" class="text-center text-muted py-4">Заказы не найдены</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div v-if="orderForm" class="card border-dark mt-4">
+            <div class="card-header bg-dark text-white">Редактирование заказа #{{ orderForm.id }}</div>
+            <div class="card-body">
+              <form @submit.prevent="saveOrder">
+                <div class="row g-3">
+                  <div class="col-md-4">
+                    <label class="form-label" for="orderStatus">Статус</label>
+                    <select id="orderStatus" v-model="orderForm.statusId" class="form-select" required>
+                      <option value="">Выберите статус</option>
+                      <option v-for="status in orderStatuses" :key="status.id" :value="String(status.id)">
+                        {{ status.name }}
+                      </option>
+                    </select>
+                  </div>
+                  <div class="col-md-4">
+                    <label class="form-label" for="orderTotal">Сумма (₽)</label>
+                    <input
+                      id="orderTotal"
+                      v-model="orderForm.totalAmount"
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      class="form-control"
+                      required
+                    />
+                  </div>
+                  <div class="col-md-4">
+                    <label class="form-label" for="orderPayment">Способ оплаты</label>
+                    <input
+                      id="orderPayment"
+                      v-model="orderForm.paymentMethod"
+                      type="text"
+                      class="form-control"
+                      placeholder="Например, Банковская карта"
+                    />
+                  </div>
+                  <div class="col-12">
+                    <label class="form-label" for="orderComment">Комментарий</label>
+                    <textarea
+                      id="orderComment"
+                      v-model="orderForm.comment"
+                      class="form-control"
+                      rows="3"
+                      placeholder="Комментарий к заказу"
+                    ></textarea>
+                  </div>
+                </div>
+                <div class="d-flex justify-content-between align-items-center mt-4">
+                  <button class="btn btn-primary" type="submit" :disabled="orderSaving">
+                    Сохранить изменения
+                  </button>
+                  <button class="btn btn-outline-secondary" type="button" @click="cancelOrderEdit" :disabled="orderSaving">
+                    Отменить
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import LoadingSpinner from '../components/LoadingSpinner.vue';
+import {
+  fetchProducts,
+  updateProduct,
+  deleteProduct,
+  type ProductDto,
+  type UpdateProductPayload,
+} from '../api/products';
+import { fetchCategories, type CategoryDto } from '../api/categories';
+import { fetchSizes, type SizeDto } from '../api/sizes';
+import {
+  fetchOrders,
+  fetchOrderStatuses,
+  updateOrder,
+  deleteOrder,
+  type OrderDto,
+  type OrderStatusDto,
+  type UpdateOrderPayload,
+} from '../api/orders';
+import { extractErrorMessage } from '../api/http';
+
+interface ProductFormState {
+  id: number;
+  title: string;
+  description: string;
+  price: string;
+  sku: string;
+  stockCount: string;
+  imageUrl: string;
+  categoryId: string;
+  sizeId: string;
+}
+
+interface OrderFormState {
+  id: number;
+  statusId: string;
+  totalAmount: string;
+  paymentMethod: string;
+  comment: string;
+}
+
+const products = ref<ProductDto[]>([]);
+const orders = ref<OrderDto[]>([]);
+const categories = ref<CategoryDto[]>([]);
+const sizes = ref<SizeDto[]>([]);
+const orderStatuses = ref<OrderStatusDto[]>([]);
+
+const initialLoading = ref(false);
+const productsLoading = ref(false);
+const ordersLoading = ref(false);
+const productSaving = ref(false);
+const orderSaving = ref(false);
+
+const globalError = ref<string | null>(null);
+const successMessage = ref<string | null>(null);
+
+const productForm = ref<ProductFormState | null>(null);
+const orderForm = ref<OrderFormState | null>(null);
+
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 2,
+  }).format(value);
+};
+
+const formatDate = (date: string) => {
+  const parsed = new Date(date);
+  return parsed.toLocaleString('ru-RU');
+};
+
+const showError = (error: unknown) => {
+  globalError.value = typeof error === 'string' ? error : extractErrorMessage(error);
+  successMessage.value = null;
+};
+
+const showSuccess = (message: string) => {
+  successMessage.value = message;
+  globalError.value = null;
+};
+
+const loadInitialData = async () => {
+  try {
+    initialLoading.value = true;
+    globalError.value = null;
+    const [productsData, ordersData, categoriesData, sizesData, statusesData] = await Promise.all([
+      fetchProducts(),
+      fetchOrders(),
+      fetchCategories(),
+      fetchSizes(),
+      fetchOrderStatuses(),
+    ]);
+    products.value = productsData;
+    orders.value = ordersData;
+    categories.value = categoriesData;
+    sizes.value = sizesData;
+    orderStatuses.value = statusesData;
+  } catch (error) {
+    showError(error);
+  } finally {
+    initialLoading.value = false;
+  }
+};
+
+const refreshProducts = async () => {
+  try {
+    productsLoading.value = true;
+    products.value = await fetchProducts();
+    showSuccess('Список товаров обновлен');
+  } catch (error) {
+    showError(error);
+  } finally {
+    productsLoading.value = false;
+  }
+};
+
+const refreshOrders = async () => {
+  try {
+    ordersLoading.value = true;
+    orders.value = await fetchOrders();
+    showSuccess('Список заказов обновлен');
+  } catch (error) {
+    showError(error);
+  } finally {
+    ordersLoading.value = false;
+  }
+};
+
+const startEditProduct = (product: ProductDto) => {
+  productForm.value = {
+    id: product.id,
+    title: product.title,
+    description: product.description ?? '',
+    price: product.price.toString(),
+    sku: product.sku,
+    stockCount: product.stockCount.toString(),
+    imageUrl: product.imageUrl ?? '',
+    categoryId: product.category ? String(product.category.id) : '',
+    sizeId: product.size ? String(product.size.id) : '',
+  };
+  successMessage.value = null;
+};
+
+const cancelProductEdit = () => {
+  productForm.value = null;
+};
+
+const saveProduct = async () => {
+  if (!productForm.value) {
+    return;
+  }
+
+  const price = Number.parseFloat(productForm.value.price);
+  const stockCount = Number.parseInt(productForm.value.stockCount, 10);
+  const categoryId = Number.parseInt(productForm.value.categoryId, 10);
+  const sizeId = productForm.value.sizeId ? Number.parseInt(productForm.value.sizeId, 10) : null;
+
+  if (Number.isNaN(price) || Number.isNaN(stockCount) || Number.isNaN(categoryId)) {
+    showError('Проверьте корректность заполнения полей товара');
+    return;
+  }
+
+  const payload: UpdateProductPayload = {
+    title: productForm.value.title.trim(),
+    description: productForm.value.description.trim(),
+    price,
+    sku: productForm.value.sku.trim(),
+    stockCount,
+    imageUrl: productForm.value.imageUrl.trim(),
+    categoryId,
+    sizeId: sizeId ?? null,
+  };
+
+  try {
+    productSaving.value = true;
+    const updated = await updateProduct(productForm.value.id, payload);
+    products.value = products.value.map((item) => (item.id === updated.id ? updated : item));
+    showSuccess(`Товар #${updated.id} успешно обновлен`);
+    startEditProduct(updated);
+  } catch (error) {
+    showError(error);
+  } finally {
+    productSaving.value = false;
+  }
+};
+
+const removeProduct = async (product: ProductDto) => {
+  const confirmed = window.confirm(`Удалить товар «${product.title}»?`);
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    await deleteProduct(product.id);
+    products.value = products.value.filter((item) => item.id !== product.id);
+    if (productForm.value?.id === product.id) {
+      productForm.value = null;
+    }
+    showSuccess('Товар удален');
+  } catch (error) {
+    showError(error);
+  }
+};
+
+const startEditOrder = (order: OrderDto) => {
+  orderForm.value = {
+    id: order.id,
+    statusId: String(order.status.id),
+    totalAmount: order.totalAmount.toString(),
+    paymentMethod: order.paymentMethod ?? '',
+    comment: order.comment ?? '',
+  };
+  successMessage.value = null;
+};
+
+const cancelOrderEdit = () => {
+  orderForm.value = null;
+};
+
+const saveOrder = async () => {
+  if (!orderForm.value) {
+    return;
+  }
+
+  const statusId = Number.parseInt(orderForm.value.statusId, 10);
+  const totalAmount = Number.parseFloat(orderForm.value.totalAmount);
+
+  if (Number.isNaN(statusId) || Number.isNaN(totalAmount)) {
+    showError('Проверьте корректность заполнения полей заказа');
+    return;
+  }
+
+  const payload: UpdateOrderPayload = {
+    statusId,
+    totalAmount,
+    paymentMethod: orderForm.value.paymentMethod.trim(),
+    comment: orderForm.value.comment.trim(),
+  };
+
+  try {
+    orderSaving.value = true;
+    const updated = await updateOrder(orderForm.value.id, payload);
+    orders.value = orders.value.map((item) => (item.id === updated.id ? updated : item));
+    showSuccess(`Заказ #${updated.id} успешно обновлен`);
+    startEditOrder(updated);
+  } catch (error) {
+    showError(error);
+  } finally {
+    orderSaving.value = false;
+  }
+};
+
+const removeOrder = async (order: OrderDto) => {
+  const confirmed = window.confirm(`Удалить заказ #${order.id}?`);
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    await deleteOrder(order.id);
+    orders.value = orders.value.filter((item) => item.id !== order.id);
+    if (orderForm.value?.id === order.id) {
+      orderForm.value = null;
+    }
+    showSuccess('Заказ удален');
+  } catch (error) {
+    showError(error);
+  }
+};
+
+onMounted(async () => {
+  await loadInitialData();
+});
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -28,6 +28,11 @@ const routes: RouteRecordRaw[] = [
     name: 'auth',
     component: () => import('../pages/AuthPage.vue'),
   },
+  {
+    path: '/admin',
+    name: 'admin',
+    component: () => import('../pages/AdminPage.vue'),
+  },
 ];
 
 export const router = createRouter({


### PR DESCRIPTION
## Summary
- add backend order and order-status modules to expose CRUD endpoints for the admin panel
- build a Vue /admin page with editable tables for products and orders plus supporting API clients
- link the new route from the navbar and log the task progress

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5173
- curl -I http://localhost:5173


------
https://chatgpt.com/codex/tasks/task_e_68e5811149e483219e334204fdf4416e