### PR TITLE
Seed initial products for catalog and configure frontend API URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 *.env
+!frontend/.env
 
 # Editor settings
 /.vscode/

--- a/Tasks/TASK_fix_products-loading.MD
+++ b/Tasks/TASK_fix_products-loading.MD
@@ -1,0 +1,19 @@
+# TASK_fix_products-loading
+
+## Что было сделано
+- Проверил подключение фронтенда к API и обнаружил отсутствие данных из таблицы `products`.
+- Добавил наполнение каталога в `backend/database/schema.sql`, чтобы при инициализации БД создавались тестовые товары, и сделал поле `name` в размерах уникальным на уровне TypeORM.
+- Создал файл `frontend/.env` с `VITE_API_URL=http://localhost:3000`, чтобы фронтенд явно обращался к локальному бэкенду.
+
+## Изменения
+- `backend/database/schema.sql` — добавлено заполнение таблицы `products` и безопасные вставки для размеров.
+- `backend/src/modules/sizes/entities/size.entity.ts` — включено ограничение `unique` для поля `name`.
+- `.gitignore` и `frontend/.env` — разрешил коммит файла окружения фронтенда и задал целевой URL API.
+
+## Проверка
+1. Запустить бэкенд: `cd backend && npm run start:dev`.
+2. Запустить фронтенд: `cd frontend && npm run dev -- --host 0.0.0.0 --port 5173`.
+3. Открыть `http://localhost:5173/` и убедиться, что раздел «Популярные товары» выводит позиции из базы данных.
+
+## Скриншот
+![Главная страница с товарами](browser:/invocations/cgorkgjs/artifacts/artifacts/catalog.png)

--- a/backend/src/modules/sizes/entities/size.entity.ts
+++ b/backend/src/modules/sizes/entities/size.entity.ts
@@ -11,7 +11,7 @@ export class SizeEntity {
   id: number;
 
   // human readable name of the size
-  @Column({ type: 'varchar', length: 50 })
+  @Column({ type: 'varchar', length: 50, unique: true })
   @ApiProperty({ example: 'L', description: 'Название размера' })
   name: string;
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- populate the products table with deterministic seed data and idempotent inserts in `schema.sql`
- mark size names as unique in the TypeORM entity so the catalogue seeds remain valid
- allow checking in the frontend `.env`, set `VITE_API_URL`, and document the fix in Tasks/TASK_fix_products-loading.MD

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68e6336b03bc8321b5c90866f8851b67