### PR TITLE
Remove redundant logout controls from profile and hero

### DIFF
--- a/Tasks/TASK_auth_redirect-and-logout.MD
+++ b/Tasks/TASK_auth_redirect-and-logout.MD
@@ -1,0 +1,26 @@
+# TASK_auth_redirect-and-logout
+
+## Что было сделано
+- Настроен хранитель авторизации: токены сохраняются в `localStorage`, сессия восстанавливается при запуске, после логина и регистрации выполняется переход на главную.
+- Кнопки "Вход"/"Выход" теперь отображаются только в навигации, главный экран без дополнительных CTA; компонент профиля сфокусирован на данных пользователя.
+- Создан и переиспользован модальный компонент подтверждения выхода, который блокирует прокрутку и очищает авторизацию после подтверждения.
+
+## Изменения
+- `frontend/src/store/authStore.ts`
+- `frontend/src/main.ts`
+- `frontend/src/components/AppNavbar.vue`
+- `frontend/src/components/LogoutConfirmModal.vue`
+- `frontend/src/pages/HomePage.vue`
+- `frontend/src/pages/AuthPage.vue`
+- `frontend/src/pages/ProfilePage.vue`
+
+## Проверка
+- Регистрация нового пользователя и автоматический переход на `/`.
+- После повторной загрузки страницы сохранена авторизация и отображается кнопка "Выход" только в шапке.
+- Кнопка "Выход" открывает модальное окно с подтверждением, после подтверждения выполняется выход и возврат на главную.
+- Скриншоты состояния интерфейса:
+  - До входа: ![До входа](browser:/invocations/muenwygh/artifacts/artifacts/home-before-login.png)
+  - После входа: ![После входа](browser:/invocations/muenwygh/artifacts/artifacts/home-after-login.png)
+  - После выхода: ![После выхода](browser:/invocations/muenwygh/artifacts/artifacts/home-after-logout.png)
+  - Модальное подтверждение выхода: ![Модальное окно](browser:/invocations/muenwygh/artifacts/artifacts/home-logout-modal.png)
+  - Страница профиля: ![Профиль](browser:/invocations/muenwygh/artifacts/artifacts/profile-page.png)

--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -31,17 +31,40 @@
             <RouterLink class="nav-link" to="/admin/users">Управление пользователями</RouterLink>
           </li>
         </ul>
-        <RouterLink class="btn btn-outline-light" to="/login">Войти</RouterLink>
+        <div class="d-flex align-items-center gap-2">
+          <RouterLink v-if="!isAuthenticated" class="btn btn-outline-light" to="/login">Вход</RouterLink>
+          <button v-else class="btn btn-outline-light" type="button" @click="openModal">Выход</button>
+        </div>
       </div>
     </div>
+    <LogoutConfirmModal :visible="showModal" @confirm="handleLogout" @cancel="closeModal" />
   </nav>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { storeToRefs } from 'pinia';
-import { RouterLink } from 'vue-router';
+import { RouterLink, useRouter } from 'vue-router';
 import { useAuthStore } from '../store/authStore';
+import LogoutConfirmModal from './LogoutConfirmModal.vue';
 
 const authStore = useAuthStore();
-const { user } = storeToRefs(authStore);
+const router = useRouter();
+const { user, isAuthenticated } = storeToRefs(authStore);
+
+const showModal = ref(false);
+
+const openModal = () => {
+  showModal.value = true;
+};
+
+const closeModal = () => {
+  showModal.value = false;
+};
+
+const handleLogout = async () => {
+  authStore.logout();
+  closeModal();
+  await router.push('/');
+};
 </script>

--- a/frontend/src/components/LogoutConfirmModal.vue
+++ b/frontend/src/components/LogoutConfirmModal.vue
@@ -1,0 +1,102 @@
+<template>
+  <Teleport to="body">
+    <transition name="fade">
+      <div v-if="visible" class="modal-backdrop fade show"></div>
+    </transition>
+    <transition name="scale">
+      <div
+        v-if="visible"
+        class="modal d-block"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="logout-modal-title"
+      >
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content shadow-lg">
+            <div class="modal-body text-center p-4">
+              <p id="logout-modal-title" class="fs-5 mb-4">
+                Вы действительно хотите выйти из аккаунта?
+              </p>
+              <div class="d-flex justify-content-center gap-3">
+                <button type="button" class="btn btn-danger" @click="emitConfirm">Да</button>
+                <button type="button" class="btn btn-outline-secondary" @click="emitCancel">Отмена</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, watch } from 'vue';
+
+const props = defineProps<{ visible: boolean }>();
+const emit = defineEmits<{
+  (event: 'confirm'): void;
+  (event: 'cancel'): void;
+}>();
+
+const visible = computed(() => props.visible);
+
+const handleKeyup = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && visible.value) {
+    emit('cancel');
+  }
+};
+
+watch(
+  visible,
+  (value) => {
+    if (value) {
+      window.addEventListener('keyup', handleKeyup);
+      document.body.classList.add('modal-open');
+    } else {
+      window.removeEventListener('keyup', handleKeyup);
+      document.body.classList.remove('modal-open');
+    }
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keyup', handleKeyup);
+  document.body.classList.remove('modal-open');
+});
+
+const emitConfirm = () => {
+  emit('confirm');
+};
+
+const emitCancel = () => {
+  emit('cancel');
+};
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.scale-enter-active,
+.scale-leave-active {
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.scale-enter-from,
+.scale-leave-to {
+  transform: scale(0.95);
+  opacity: 0;
+}
+
+:global(body.modal-open) {
+  overflow: hidden;
+}
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,10 +5,21 @@ import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import './style.css';
 import App from './App.vue';
 import { router } from './router';
+import { useAuthStore } from './store/authStore';
 
 const app = createApp(App);
+const pinia = createPinia();
 
-app.use(createPinia());
+app.use(pinia);
 app.use(router);
 
-app.mount('#app');
+const authStore = useAuthStore(pinia);
+
+authStore
+  .initialize()
+  .catch(() => {
+    // Session restore errors are handled inside the store.
+  })
+  .finally(() => {
+    app.mount('#app');
+  });

--- a/frontend/src/pages/AuthPage.vue
+++ b/frontend/src/pages/AuthPage.vue
@@ -103,8 +103,7 @@ const handleSubmit = async () => {
     if (mode.value === 'login') {
       await authStore.loginUser({ email: form.email, password: form.password });
       success.value = 'Вход выполнен успешно!';
-      const redirectTarget = typeof route.query.redirect === 'string' ? route.query.redirect : '/';
-      await router.push(redirectTarget);
+      await router.push('/');
     } else {
       await authStore.registerUser({
         name: form.name,
@@ -113,6 +112,7 @@ const handleSubmit = async () => {
         phone: form.phone || undefined,
       });
       success.value = 'Аккаунт создан! Добро пожаловать.';
+      await router.push('/');
     }
   } catch (err) {
     console.error('Auth request failed', err);

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -1,11 +1,8 @@
 <template>
   <section class="py-5">
     <div class="container">
-      <div class="d-flex justify-content-between align-items-center mb-4">
+      <div class="mb-4">
         <h1 class="display-6 fw-bold">Профиль</h1>
-        <button v-if="isAuthenticated" class="btn btn-outline-danger" @click="logout">
-          Выйти
-        </button>
       </div>
       <div v-if="!isAuthenticated" class="alert alert-warning" role="alert">
         Выполните вход, чтобы просмотреть информацию профиля.
@@ -47,9 +44,5 @@ const { user, loading, error, isAuthenticated } = storeToRefs(authStore);
 
 const loadProfile = async () => {
   await authStore.loadProfile();
-};
-
-const logout = () => {
-  authStore.logout();
 };
 </script>


### PR DESCRIPTION
## Summary
- remove the dedicated logout button from the profile header and keep the profile layout focused on account data
- drop the hero login/logout call-to-action and related modal wiring so that the navbar remains the central auth control
- refresh the auth task report with updated screenshots that showcase the navbar-only login/logout flow

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68e6436b7cf4832182fcc2aa5619974d