### PR TITLE
feat: enable profile address management and checkout checks

### DIFF
--- a/Tasks/TASK_13_profile-address.MD
+++ b/Tasks/TASK_13_profile-address.MD
@@ -1,0 +1,14 @@
+# TASK_13_profile-address
+
+## Что было сделано
+Реализовано редактирование профиля с адресом доставки и проверкой страны на фронтенде и бекенде. Добавлены поля country, city, address в таблицу users и обработчики сохранения данных.
+
+## Изменения
+- backend/src/modules/users/**/* — новые поля и эндпоинт обновления профиля.
+- backend/src/modules/carts/carts.service.ts — проверка страны и адреса при оформлении заказа.
+- backend/database/schema.sql — обновлённая схема с полями адреса.
+- frontend/src/pages/ProfilePage.vue, CheckoutPaymentPage.vue, store и API — формы редактирования и проверки адреса.
+
+## Проверка
+- Backend: `npm run start:dev` (успешно после настройки PostgreSQL).
+- Frontend: `npm run dev -- --host`.

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -12,6 +12,9 @@ CREATE TABLE IF NOT EXISTS users (
     email VARCHAR(150) NOT NULL UNIQUE,
     password_hash VARCHAR(255) NOT NULL,
     phone VARCHAR(30),
+    country VARCHAR(100),
+    city VARCHAR(100),
+    address TEXT,
     role_id INTEGER NOT NULL REFERENCES roles(id),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL

--- a/backend/src/modules/carts/carts.service.ts
+++ b/backend/src/modules/carts/carts.service.ts
@@ -114,6 +114,27 @@ export class CartsService {
       throw new BadRequestException('Корзина пуста');
     }
 
+    const user = cart.user;
+
+    if (!user) {
+      throw new NotFoundException('Пользователь не найден');
+    }
+
+    const normalizedCountry = user.country?.trim();
+    if (normalizedCountry && normalizedCountry.toLowerCase() !== 'россия') {
+      throw new BadRequestException(
+        'Оформление заказов доступно только пользователям из России.',
+      );
+    }
+
+    const hasAddress = Boolean(
+      normalizedCountry && user.city?.trim() && user.address?.trim(),
+    );
+
+    if (!hasAddress) {
+      throw new BadRequestException('Укажите адрес доставки в профиле');
+    }
+
     const status = await this.orderStatusesRepository.findOne({ where: { name: 'Новый' } });
 
     if (!status) {

--- a/backend/src/modules/users/dto/create-user.dto.ts
+++ b/backend/src/modules/users/dto/create-user.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEmail, IsOptional, IsPhoneNumber, IsString, Length } from 'class-validator';
+import {
+  IsEmail,
+  IsOptional,
+  IsPhoneNumber,
+  IsString,
+  Length,
+  MaxLength,
+} from 'class-validator';
 
 // dto for creating user
 export class CreateUserDto {
@@ -21,6 +28,24 @@ export class CreateUserDto {
   @IsOptional()
   @IsPhoneNumber('RU', { message: 'Введите корректный номер телефона' })
   phone?: string;
+
+  @ApiPropertyOptional({ example: 'Россия', description: 'Страна пользователя' })
+  @IsOptional()
+  @IsString({ message: 'Страна должна быть строкой' })
+  @MaxLength(100, { message: 'Страна должна содержать не более 100 символов' })
+  country?: string;
+
+  @ApiPropertyOptional({ example: 'Москва', description: 'Город пользователя' })
+  @IsOptional()
+  @IsString({ message: 'Город должен быть строкой' })
+  @MaxLength(100, { message: 'Город должен содержать не более 100 символов' })
+  city?: string;
+
+  @ApiPropertyOptional({ example: 'ул. Арбат, д. 12, кв. 34', description: 'Полный адрес пользователя' })
+  @IsOptional()
+  @IsString({ message: 'Адрес должен быть строкой' })
+  @MaxLength(500, { message: 'Адрес должен содержать не более 500 символов' })
+  address?: string;
 
   @ApiPropertyOptional({ example: 'Администратор', description: 'Название роли' })
   @IsOptional()

--- a/backend/src/modules/users/dto/update-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-profile.dto.ts
@@ -2,51 +2,51 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsEmail, IsOptional, IsString, Length, MaxLength } from 'class-validator';
 
-// dto for updating user data by administrator
-export class UpdateUserDto {
-  @ApiPropertyOptional({ example: 'Сид Уилсон', description: 'Новое имя пользователя' })
+// dto for updating current user profile
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ example: 'Мик Томсон', description: 'Имя пользователя' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Имя должно быть строкой' })
   @Length(2, 150, { message: 'Имя должно содержать от 2 до 150 символов' })
   name?: string;
 
-  @ApiPropertyOptional({ example: 'sid@slipknot.com', description: 'Новый email' })
+  @ApiPropertyOptional({ example: 'mick@slipknot.com', description: 'Электронная почта' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsEmail({}, { message: 'Введите корректный email' })
   @MaxLength(150, { message: 'Email должен содержать не более 150 символов' })
   email?: string;
 
-  @ApiPropertyOptional({ example: '+7 (900) 765-43-21', description: 'Новый номер телефона' })
+  @ApiPropertyOptional({ example: '+7 (900) 654-32-10', description: 'Номер телефона' })
   @IsOptional()
   @Transform(({ value }) => (value === null ? undefined : typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Телефон должен быть строкой' })
   @MaxLength(30, { message: 'Телефон должен содержать не более 30 символов' })
   phone?: string;
 
-  @ApiPropertyOptional({ example: 'Менеджер', description: 'Роль пользователя' })
+  @ApiPropertyOptional({ example: 'НадёжныйПароль123', description: 'Новый пароль' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
-  @IsString({ message: 'Роль должна быть строкой' })
-  @MaxLength(100, { message: 'Роль должна содержать не более 100 символов' })
-  roleName?: string;
+  @IsString({ message: 'Пароль должен быть строкой' })
+  @Length(6, 100, { message: 'Пароль должен содержать от 6 до 100 символов' })
+  password?: string;
 
-  @ApiPropertyOptional({ example: 'Россия', description: 'Страна пользователя' })
+  @ApiPropertyOptional({ example: 'Россия', description: 'Страна проживания' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Страна должна быть строкой' })
   @MaxLength(100, { message: 'Страна должна содержать не более 100 символов' })
   country?: string;
 
-  @ApiPropertyOptional({ example: 'Москва', description: 'Город пользователя' })
+  @ApiPropertyOptional({ example: 'Москва', description: 'Город проживания' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Город должен быть строкой' })
   @MaxLength(100, { message: 'Город должен содержать не более 100 символов' })
   city?: string;
 
-  @ApiPropertyOptional({ example: 'ул. Арбат, д. 12, кв. 34', description: 'Адрес пользователя' })
+  @ApiPropertyOptional({ example: 'ул. Арбат, д. 12, кв. 34', description: 'Полный адрес проживания' })
   @IsOptional()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Адрес должен быть строкой' })

--- a/backend/src/modules/users/dto/user-response.dto.ts
+++ b/backend/src/modules/users/dto/user-response.dto.ts
@@ -22,6 +22,15 @@ export class UserResponseDto {
   @ApiPropertyOptional({ example: '+7 (900) 123-45-67', description: 'Номер телефона' })
   phone?: string | null;
 
+  @ApiPropertyOptional({ example: 'Россия', description: 'Страна пользователя' })
+  country?: string | null;
+
+  @ApiPropertyOptional({ example: 'Москва', description: 'Город пользователя' })
+  city?: string | null;
+
+  @ApiPropertyOptional({ example: 'ул. Арбат, д. 12, кв. 34', description: 'Полный адрес пользователя' })
+  address?: string | null;
+
   @ApiProperty({ type: () => UserRoleDto, nullable: true, description: 'Роль пользователя' })
   role: UserRoleDto | null;
 

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -33,6 +33,15 @@ export class User {
   @Column({ type: 'varchar', length: 30, nullable: true })
   phone?: string | null;
 
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  country?: string | null;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  city?: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  address?: string | null;
+
   @ManyToOne(() => Role, (role) => role.users, { eager: false })
   @JoinColumn({ name: 'role_id' })
   role: Role;

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -27,6 +27,7 @@ import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserResponseDto, UserRoleDto } from './dto/user-response.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UsersService } from './users.service';
 
 type RequestWithUser = Request & { user?: { userId?: number } };
@@ -50,6 +51,24 @@ export class UsersController {
     }
 
     return this.usersService.findById(userId);
+  }
+
+  @Put('me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Обновить профиль текущего пользователя' })
+  @ApiOkResponse({ description: 'Обновлённые данные пользователя', type: UserResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Пользователь не авторизован' })
+  async updateProfile(
+    @Req() req: RequestWithUser,
+    @Body() dto: UpdateProfileDto,
+  ): Promise<UserResponseDto> {
+    const userId = req.user?.userId;
+    if (!userId) {
+      throw new UnauthorizedException('Требуется авторизация');
+    }
+
+    return this.usersService.updateProfile(userId, dto);
   }
 
   @Get()

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -9,6 +9,9 @@ export interface LoginPayload {
 export interface RegisterPayload extends LoginPayload {
   name: string;
   phone?: string;
+  country?: string;
+  city?: string;
+  address?: string;
 }
 
 export interface AuthResponse {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -10,6 +10,9 @@ export interface UserProfile {
   name: string;
   email: string;
   phone?: string | null;
+  country?: string | null;
+  city?: string | null;
+  address?: string | null;
   role: UserRole | null;
   createdAt: string;
   updatedAt: string;
@@ -22,6 +25,19 @@ export interface UpdateUserPayload {
   email: string;
   phone: string;
   roleName: string;
+  country?: string;
+  city?: string;
+  address?: string;
+}
+
+export interface UpdateProfilePayload {
+  name?: string;
+  email?: string;
+  phone?: string | null;
+  password?: string;
+  country?: string | null;
+  city?: string | null;
+  address?: string | null;
 }
 
 export const fetchProfile = async (): Promise<UserProfile> => {
@@ -46,4 +62,9 @@ export const updateUser = async (id: number, payload: UpdateUserPayload): Promis
 
 export const deleteUser = async (id: number): Promise<void> => {
   await http.delete(`/users/${id}`);
+};
+
+export const updateProfile = async (payload: UpdateProfilePayload): Promise<UserProfile> => {
+  const { data } = await http.put<UserProfile>('/users/me', payload);
+  return data;
 };

--- a/frontend/src/pages/CheckoutPaymentPage.vue
+++ b/frontend/src/pages/CheckoutPaymentPage.vue
@@ -59,7 +59,7 @@
                     type="button"
                     class="btn btn-danger w-100"
                     @click="payOrder"
-                    :disabled="updating || !items.length"
+                    :disabled="updating || !items.length || addressSaving"
                   >
                     Оплатить
                   </button>
@@ -73,19 +73,192 @@
       </div>
     </div>
   </section>
+
+  <div v-if="showCountryModal" class="modal fade show d-block" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title h5">Заказ недоступен</h2>
+          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeCountryModal"></button>
+        </div>
+        <div class="modal-body">
+          <p class="mb-0">Оформление заказов доступно только пользователям из России.</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="closeCountryModal">Понятно</button>
+          <RouterLink class="btn btn-danger" to="/profile" @click="closeCountryModal">
+            Перейти в профиль
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div v-if="showCountryModal" class="modal-backdrop fade show"></div>
+
+  <div v-if="showAddressModal" class="modal fade show d-block" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <form @submit.prevent="submitAddress">
+          <div class="modal-header">
+            <h2 class="modal-title h5">Укажите адрес доставки</h2>
+            <button
+              type="button"
+              class="btn-close"
+              aria-label="Закрыть"
+              @click="closeAddressModal"
+              :disabled="addressSaving"
+            ></button>
+          </div>
+          <div class="modal-body text-dark">
+            <p class="text-muted">Для оформления заказа заполните все поля.</p>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="checkoutCountry" class="form-label">Страна</label>
+                <select
+                  id="checkoutCountry"
+                  v-model="addressForm.country"
+                  class="form-select"
+                  required
+                >
+                  <option value="">Выберите страну</option>
+                  <option v-for="country in countries" :key="country" :value="country">{{ country }}</option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label class="form-label">Город</label>
+                <div class="d-flex gap-2">
+                  <select
+                    v-if="!addressForm.useCustomCity"
+                    v-model="addressForm.city"
+                    class="form-select flex-grow-1"
+                    :disabled="!addressForm.country"
+                    required
+                  >
+                    <option value="">Выберите город</option>
+                    <option v-for="cityOption in addressCityOptions" :key="cityOption" :value="cityOption">
+                      {{ cityOption }}
+                    </option>
+                  </select>
+                  <input
+                    v-else
+                    v-model="addressForm.customCity"
+                    type="text"
+                    class="form-control flex-grow-1"
+                    placeholder="Введите город"
+                    required
+                  />
+                  <button type="button" class="btn btn-outline-secondary" @click="toggleAddressCityInput">
+                    {{ addressForm.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
+                  </button>
+                </div>
+                <small class="text-muted">Выберите город или введите свой</small>
+              </div>
+              <div class="col-12">
+                <label for="checkoutAddress" class="form-label">Адрес</label>
+                <textarea
+                  id="checkoutAddress"
+                  v-model="addressForm.address"
+                  class="form-control"
+                  rows="3"
+                  placeholder="Улица, дом, квартира"
+                  required
+                ></textarea>
+              </div>
+            </div>
+            <p v-if="addressError" class="alert alert-danger mt-3 mb-0">{{ addressError }}</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="closeAddressModal" :disabled="addressSaving">
+              Отмена
+            </button>
+            <button type="submit" class="btn btn-danger" :disabled="addressSaving">
+              {{ addressSaving ? 'Сохранение...' : 'Сохранить адрес' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div v-if="showAddressModal" class="modal-backdrop fade show"></div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import { useCartStore } from '../store/cartStore';
+import { useAuthStore } from '../store/authStore';
+import { extractErrorMessage } from '../api/http';
 
 const cartStore = useCartStore();
 const { items, totalAmount, totalQuantity, loading, updating, error, lastOrder } = storeToRefs(cartStore);
 
 const localError = ref<string | null>(null);
+
+const authStore = useAuthStore();
+const { user } = storeToRefs(authStore);
+
+const showAddressModal = ref(false);
+const showCountryModal = ref(false);
+const addressError = ref<string | null>(null);
+const addressSaving = ref(false);
+
+const countries = [
+  'Россия',
+  'Беларусь',
+  'Казахстан',
+  'Армения',
+  'Грузия',
+  'Другая страна',
+];
+
+const citiesByCountry: Record<string, string[]> = {
+  Россия: ['Москва', 'Санкт-Петербург', 'Новосибирск', 'Екатеринбург', 'Казань'],
+  Беларусь: ['Минск', 'Гомель', 'Витебск', 'Могилёв'],
+  Казахстан: ['Астана', 'Алматы', 'Шымкент', 'Караганда'],
+  Армения: ['Ереван', 'Гюмри', 'Ванадзор'],
+  Грузия: ['Тбилиси', 'Батуми', 'Кутаиси'],
+  'Другая страна': [],
+};
+
+const addressForm = reactive({
+  country: 'Россия',
+  city: '',
+  customCity: '',
+  useCustomCity: false,
+  address: '',
+});
+
+const addressCityOptions = computed(() => citiesByCountry[addressForm.country] ?? []);
+
+const addressResolvedCity = computed(() => {
+  const value = addressForm.useCustomCity ? addressForm.customCity : addressForm.city;
+  return value.trim();
+});
+
+watch(
+  () => addressForm.country,
+  (country) => {
+    const options = citiesByCountry[country] ?? [];
+    if (!country) {
+      addressForm.city = '';
+      addressForm.useCustomCity = false;
+      addressForm.customCity = '';
+      return;
+    }
+
+    if (!options.includes(addressForm.city)) {
+      addressForm.city = '';
+    }
+    if (!addressForm.useCustomCity) {
+      addressForm.customCity = '';
+    }
+  },
+);
+
+const ONLY_RUSSIA_MESSAGE = 'Оформление заказов доступно только пользователям из России.';
+const ADDRESS_REQUIRED_SUBSTRING = 'Укажите адрес доставки';
 
 const formatCurrency = (value: number) => `${value.toLocaleString('ru-RU')} ₽`;
 
@@ -101,13 +274,146 @@ const hasItems = computed(() => items.value.length > 0);
 
 const paymentSuccess = computed(() => Boolean(lastOrder.value));
 
-const payOrder = async () => {
+const ensureProfileLoaded = async () => {
+  if (user.value) {
+    return true;
+  }
+  try {
+    await authStore.loadProfile();
+    return Boolean(user.value);
+  } catch (err) {
+    localError.value = extractErrorMessage(err) ?? 'Не удалось загрузить профиль пользователя.';
+    return false;
+  }
+};
+
+const fillAddressFormFromUser = () => {
+  const profile = user.value;
+  const profileCountry = profile?.country?.trim();
+  addressForm.country = profileCountry ? profileCountry : 'Россия';
+  addressForm.address = profile?.address ?? '';
+
+  const availableCities = citiesByCountry[addressForm.country] ?? [];
+  const profileCity = profile?.city ?? '';
+  if (profileCity && availableCities.includes(profileCity)) {
+    addressForm.city = profileCity;
+    addressForm.useCustomCity = false;
+    addressForm.customCity = '';
+  } else if (profileCity) {
+    addressForm.city = '';
+    addressForm.useCustomCity = true;
+    addressForm.customCity = profileCity;
+  } else {
+    addressForm.city = '';
+    addressForm.useCustomCity = false;
+    addressForm.customCity = '';
+  }
+};
+
+const openAddressModal = () => {
+  fillAddressFormFromUser();
+  addressError.value = null;
+  showAddressModal.value = true;
+};
+
+const closeAddressModal = () => {
+  if (addressSaving.value) {
+    return;
+  }
+  showAddressModal.value = false;
+};
+
+const toggleAddressCityInput = () => {
+  addressForm.useCustomCity = !addressForm.useCustomCity;
+  if (addressForm.useCustomCity) {
+    addressForm.city = '';
+  } else {
+    addressForm.customCity = '';
+  }
+};
+
+const proceedCheckout = async () => {
   const result = await cartStore.checkout();
   if (!result) {
     localError.value = error.value ?? 'Не удалось оформить заказ. Попробуйте ещё раз.';
   } else {
     localError.value = null;
   }
+  return result;
+};
+
+const showCountryRestriction = () => {
+  showCountryModal.value = true;
+};
+
+const payOrder = async () => {
+  localError.value = null;
+
+  const hasProfile = await ensureProfileLoaded();
+  if (!hasProfile) {
+    return;
+  }
+
+  const profile = user.value;
+  const country = profile?.country?.trim() ?? '';
+  const city = profile?.city?.trim() ?? '';
+  const address = profile?.address?.trim() ?? '';
+
+  if (country && country.toLowerCase() !== 'россия') {
+    showCountryRestriction();
+    return;
+  }
+
+  if (!country || !city || !address) {
+    openAddressModal();
+    return;
+  }
+
+  await proceedCheckout();
+};
+
+const submitAddress = async () => {
+  addressError.value = null;
+
+  const country = addressForm.country.trim();
+  const city = addressResolvedCity.value;
+  const address = addressForm.address.trim();
+
+  if (!country) {
+    addressError.value = 'Выберите страну.';
+    return;
+  }
+
+  if (!city) {
+    addressError.value = 'Укажите город.';
+    return;
+  }
+
+  if (!address) {
+    addressError.value = 'Введите полный адрес.';
+    return;
+  }
+
+  if (country.toLowerCase() !== 'россия') {
+    showAddressModal.value = false;
+    showCountryRestriction();
+    return;
+  }
+
+  try {
+    addressSaving.value = true;
+    await authStore.updateProfile({ country, city, address });
+    showAddressModal.value = false;
+    await proceedCheckout();
+  } catch (err) {
+    addressError.value = extractErrorMessage(err) ?? 'Не удалось сохранить адрес.';
+  } finally {
+    addressSaving.value = false;
+  }
+};
+
+const closeCountryModal = () => {
+  showCountryModal.value = false;
 };
 
 onMounted(() => {
@@ -115,9 +421,20 @@ onMounted(() => {
   if (!items.value.length) {
     void cartStore.loadCart();
   }
+  if (!user.value) {
+    void authStore.loadProfile();
+  }
 });
 
 watch(error, (value) => {
   localError.value = value ?? null;
+  if (!value) {
+    return;
+  }
+  if (value === ONLY_RUSSIA_MESSAGE) {
+    showCountryRestriction();
+  } else if (value.includes(ADDRESS_REQUIRED_SUBSTRING) && !showAddressModal.value) {
+    openAddressModal();
+  }
 });
 </script>

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -1,48 +1,349 @@
 <template>
-  <section class="py-5">
+  <section class="py-5 bg-light min-vh-100">
     <div class="container">
-      <div class="mb-4">
-        <h1 class="display-6 fw-bold">Профиль</h1>
+      <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+        <h1 class="display-6 fw-bold mb-3 mb-md-0">Профиль</h1>
+        <button class="btn btn-outline-secondary" type="button" @click="refreshProfile" :disabled="loading">
+          Обновить данные
+        </button>
       </div>
+
       <div v-if="!isAuthenticated" class="alert alert-warning" role="alert">
         Выполните вход, чтобы просмотреть информацию профиля.
         <RouterLink class="alert-link" to="/auth">Перейти к авторизации</RouterLink>
       </div>
+
       <div v-else>
-        <LoadingSpinner v-if="loading" />
+        <LoadingSpinner v-if="loading && !user" />
+
         <div v-else>
-          <div v-if="error" class="alert alert-danger" role="alert">
-            {{ error }}
-          </div>
-          <div v-else-if="user" class="card shadow-sm">
-            <div class="card-body">
-              <h2 class="h5 mb-3">Личные данные</h2>
-              <p class="mb-1"><strong>Имя:</strong> {{ user.name }}</p>
-              <p class="mb-1"><strong>Email:</strong> {{ user.email }}</p>
-              <p class="mb-1"><strong>Телефон:</strong> {{ user.phone ?? 'не указан' }}</p>
-              <p class="mb-0"><strong>Роль:</strong> {{ user.role?.name ?? 'пользователь' }}</p>
+          <p v-if="localError" class="alert alert-danger">{{ localError }}</p>
+          <p v-if="successMessage" class="alert alert-success">{{ successMessage }}</p>
+
+          <div v-if="user" class="row g-4">
+            <div class="col-lg-6">
+              <form class="card shadow-sm" @submit.prevent="saveProfile">
+                <div class="card-body">
+                  <div class="d-flex justify-content-between align-items-start mb-4">
+                    <div>
+                      <h2 class="h5 mb-1">Личные данные</h2>
+                      <p class="text-muted small mb-0">Измените имя, email, телефон и пароль</p>
+                    </div>
+                    <span class="badge bg-dark">{{ user.role?.name ?? 'Покупатель' }}</span>
+                  </div>
+
+                  <div class="row g-3">
+                    <div class="col-12">
+                      <label for="profileName" class="form-label">Имя</label>
+                      <input
+                        id="profileName"
+                        v-model="form.name"
+                        type="text"
+                        class="form-control"
+                        required
+                        minlength="2"
+                        maxlength="150"
+                      />
+                    </div>
+                    <div class="col-12">
+                      <label for="profileEmail" class="form-label">Email</label>
+                      <input
+                        id="profileEmail"
+                        v-model="form.email"
+                        type="email"
+                        class="form-control"
+                        required
+                        maxlength="150"
+                      />
+                    </div>
+                    <div class="col-12">
+                      <label for="profilePhone" class="form-label">Телефон</label>
+                      <input
+                        id="profilePhone"
+                        v-model="form.phone"
+                        type="tel"
+                        class="form-control"
+                        placeholder="Например, +7 900 000-00-00"
+                        maxlength="30"
+                      />
+                    </div>
+                    <div class="col-12">
+                      <label for="profilePassword" class="form-label">Новый пароль</label>
+                      <input
+                        id="profilePassword"
+                        v-model="form.password"
+                        type="password"
+                        class="form-control"
+                        placeholder="Оставьте пустым, чтобы не менять пароль"
+                        minlength="6"
+                        maxlength="100"
+                      />
+                    </div>
+                  </div>
+
+                  <div class="d-grid mt-4">
+                    <button class="btn btn-danger" type="submit" :disabled="updating || !canSubmit">
+                      {{ updating ? 'Сохранение...' : 'Сохранить изменения' }}
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+
+            <div class="col-lg-6">
+              <div class="card shadow-sm h-100">
+                <div class="card-body">
+                  <div class="d-flex justify-content-between align-items-start mb-4">
+                    <div>
+                      <h2 class="h5 mb-1">Адрес доставки</h2>
+                      <p class="text-muted small mb-0">Страна, город и подробный адрес</p>
+                    </div>
+                    <span
+                      class="badge"
+                      :class="hasAddress ? 'bg-success' : 'bg-secondary'"
+                    >
+                      {{ hasAddress ? 'Адрес заполнен' : 'Адрес не указан' }}
+                    </span>
+                  </div>
+
+                  <div class="row g-3">
+                    <div class="col-12">
+                      <label for="profileCountry" class="form-label">Страна</label>
+                      <select
+                        id="profileCountry"
+                        v-model="form.country"
+                        class="form-select"
+                      >
+                        <option value="">Выберите страну</option>
+                        <option v-for="country in countries" :key="country" :value="country">
+                          {{ country }}
+                        </option>
+                      </select>
+                    </div>
+
+                    <div class="col-12">
+                      <label class="form-label">Город</label>
+                      <div class="d-flex gap-3">
+                        <select
+                          v-if="!form.useCustomCity"
+                          v-model="form.city"
+                          class="form-select flex-grow-1"
+                          :disabled="!form.country"
+                        >
+                          <option value="">Выберите город</option>
+                          <option v-for="cityOption in cityOptions" :key="cityOption" :value="cityOption">
+                            {{ cityOption }}
+                          </option>
+                        </select>
+                        <input
+                          v-else
+                          v-model="form.customCity"
+                          type="text"
+                          class="form-control flex-grow-1"
+                          placeholder="Введите город"
+                        />
+                        <button
+                          type="button"
+                          class="btn btn-outline-secondary"
+                          @click="toggleCityInput"
+                        >
+                          {{ form.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
+                        </button>
+                      </div>
+                      <small class="text-muted">Список городов зависит от выбранной страны</small>
+                    </div>
+
+                    <div class="col-12">
+                      <label for="profileAddress" class="form-label">Адрес</label>
+                      <textarea
+                        id="profileAddress"
+                        v-model="form.address"
+                        class="form-control"
+                        rows="3"
+                        placeholder="Улица, дом, квартира"
+                        maxlength="500"
+                      ></textarea>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
+
           <div v-else class="alert alert-info" role="alert">
             Данные профиля пока не загружены.
           </div>
         </div>
-        <button class="btn btn-secondary mt-4" @click="loadProfile">Обновить данные</button>
       </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { RouterLink } from 'vue-router';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import { useAuthStore } from '../store/authStore';
 
 const authStore = useAuthStore();
-const { user, loading, error, isAuthenticated } = storeToRefs(authStore);
+const { user, loading, updating, error, isAuthenticated } = storeToRefs(authStore);
 
-const loadProfile = async () => {
+const countries = [
+  'Россия',
+  'Беларусь',
+  'Казахстан',
+  'Армения',
+  'Грузия',
+  'Другая страна',
+];
+
+const citiesByCountry: Record<string, string[]> = {
+  Россия: ['Москва', 'Санкт-Петербург', 'Новосибирск', 'Екатеринбург', 'Казань'],
+  Беларусь: ['Минск', 'Гомель', 'Витебск', 'Могилёв'],
+  Казахстан: ['Астана', 'Алматы', 'Шымкент', 'Караганда'],
+  Армения: ['Ереван', 'Гюмри', 'Ванадзор'],
+  Грузия: ['Тбилиси', 'Батуми', 'Кутаиси'],
+  'Другая страна': [],
+};
+
+const form = reactive({
+  name: '',
+  email: '',
+  phone: '',
+  password: '',
+  country: '',
+  city: '',
+  address: '',
+  useCustomCity: false,
+  customCity: '',
+});
+
+const successMessage = ref<string | null>(null);
+const localError = ref<string | null>(null);
+
+const cityOptions = computed(() => citiesByCountry[form.country] ?? []);
+
+const hasAddress = computed(() => {
+  const cityValue = form.useCustomCity ? form.customCity.trim() : form.city.trim();
+  return Boolean(form.country && cityValue && form.address.trim());
+});
+
+const resolvedCity = computed(() => {
+  const value = form.useCustomCity ? form.customCity : form.city;
+  return value.trim();
+});
+
+const canSubmit = computed(() => Boolean(form.name.trim() && form.email.trim()));
+
+const toggleCityInput = () => {
+  form.useCustomCity = !form.useCustomCity;
+  if (form.useCustomCity) {
+    form.city = '';
+  } else {
+    form.customCity = '';
+  }
+};
+
+const applyUserToForm = () => {
+  if (!user.value) {
+    form.name = '';
+    form.email = '';
+    form.phone = '';
+    form.password = '';
+    form.country = '';
+    form.city = '';
+    form.address = '';
+    form.useCustomCity = false;
+    form.customCity = '';
+    return;
+  }
+
+  form.name = user.value.name ?? '';
+  form.email = user.value.email ?? '';
+  form.phone = user.value.phone ?? '';
+  form.password = '';
+  form.country = user.value.country ?? '';
+  form.address = user.value.address ?? '';
+
+  const availableCities = citiesByCountry[form.country] ?? [];
+  const userCity = user.value.city ?? '';
+  if (userCity && availableCities.includes(userCity)) {
+    form.city = userCity;
+    form.useCustomCity = false;
+    form.customCity = '';
+  } else if (userCity) {
+    form.city = '';
+    form.useCustomCity = true;
+    form.customCity = userCity;
+  } else {
+    form.city = '';
+    form.useCustomCity = false;
+    form.customCity = '';
+  }
+};
+
+watch(user, applyUserToForm, { immediate: true });
+
+watch(error, (value) => {
+  localError.value = value ?? null;
+});
+
+watch(
+  () => form.country,
+  (country) => {
+    const options = citiesByCountry[country] ?? [];
+    if (!country) {
+      form.city = '';
+      form.useCustomCity = false;
+      form.customCity = '';
+      return;
+    }
+
+    if (!options.includes(form.city)) {
+      form.city = '';
+    }
+    if (!form.useCustomCity) {
+      form.customCity = '';
+    }
+  },
+);
+
+const refreshProfile = async () => {
+  successMessage.value = null;
+  localError.value = null;
   await authStore.loadProfile();
 };
+
+const saveProfile = async () => {
+  successMessage.value = null;
+  localError.value = null;
+
+  const payload = {
+    name: form.name.trim(),
+    email: form.email.trim(),
+    phone: form.phone.trim() ? form.phone.trim() : null,
+    country: form.country ? form.country : null,
+    city: resolvedCity.value ? resolvedCity.value : null,
+    address: form.address.trim() ? form.address.trim() : null,
+  } as Parameters<typeof authStore.updateProfile>[0];
+
+  if (form.password.trim()) {
+    payload.password = form.password.trim();
+  }
+
+  try {
+    await authStore.updateProfile(payload);
+    successMessage.value = 'Данные профиля обновлены';
+    form.password = '';
+  } catch (err) {
+    console.error('Не удалось обновить профиль', err);
+  }
+};
+
+onMounted(() => {
+  if (!user.value && !loading.value) {
+    void authStore.loadProfile();
+  }
+});
 </script>


### PR DESCRIPTION
## Summary
- add country, city and address columns to users plus a PUT /users/me endpoint with DTO validation
- require a Russian shipping address when checking out and surface clear backend errors
- redesign the profile and checkout views to edit personal data, capture address details and show blocking modals

## Testing
- `npm run start:dev`
- `npm run dev -- --host`


------
https://chatgpt.com/codex/tasks/task_e_68e82b480c948321a4745b0fa9db8ea8