### PR TITLE
Добавление модалок создания записей для панелей менеджера и администратора

### DIFF
--- a/Tasks/TASK_16_manager-add-records.MD
+++ b/Tasks/TASK_16_manager-add-records.MD
@@ -1,0 +1,19 @@
+# TASK_16_manager-add-records
+
+## Что было сделано
+- Установлен PostgreSQL, развернута база `slipknot_shop` из `backend/database/schema.sql`, запущены dev-сервисы backend и frontend.
+- Добавлены POST-эндпоинты и DTO для создания заказов и получения покупателей, а также админский эндпоинт создания пользователя.
+- Обновлены интерфейсы менеджера и администратора: добавлены кнопки «Добавить…», модальные формы в фирменном стиле и обновления API.
+- Усилен стиль модальных окон и навигации: поддержка многострочных пунктов меню, плавные анимации, стеклянный эффект.
+
+## Изменения
+- Backend: `src/modules/orders/**`, `src/modules/users/users.controller.ts`.
+- Frontend API: `src/api/{orders,products,users}.ts`.
+- Страницы: `src/pages/ManagerPage.vue`, `src/pages/AdminUsersPage.vue`.
+- Общие стили: `src/style.css`.
+
+## Проверка
+1. Запустить PostgreSQL: `service postgresql start` (пароль пользователя `postgres` совпадает с названием).
+2. Backend: `cd backend && npm run start:dev`.
+3. Frontend: `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173`.
+4. В браузере открыть http://localhost:4173, авторизоваться и проверить добавление товаров, заказов и пользователей через новые модальные окна.

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsNumber, IsOptional, IsPositive, IsString, MaxLength, Min } from 'class-validator';
+
+// dto for creating a new order from manager panel
+export class CreateOrderDto {
+  @ApiProperty({ example: 1, description: 'Идентификатор пользователя' })
+  @Type(() => Number)
+  @IsInt({ message: 'Пользователь должен быть указан' })
+  @IsPositive({ message: 'Идентификатор пользователя должен быть положительным' })
+  userId: number;
+
+  @ApiProperty({ example: 2, description: 'Идентификатор статуса заказа' })
+  @Type(() => Number)
+  @IsInt({ message: 'Статус заказа должен быть указан' })
+  @IsPositive({ message: 'Идентификатор статуса должен быть положительным' })
+  statusId: number;
+
+  @ApiProperty({ example: 7490.5, description: 'Итоговая сумма заказа' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Сумма заказа должна быть числом' })
+  @Min(0, { message: 'Сумма заказа не может быть отрицательной' })
+  totalAmount: number;
+
+  @ApiPropertyOptional({ example: 'Банковская карта', description: 'Способ оплаты' })
+  @IsOptional()
+  @IsString({ message: 'Способ оплаты должен быть строкой' })
+  @MaxLength(100, { message: 'Способ оплаты должен содержать не более 100 символов' })
+  paymentMethod?: string;
+
+  @ApiPropertyOptional({ example: 'Готовится к отправке', description: 'Статус доставки' })
+  @IsOptional()
+  @IsString({ message: 'Статус доставки должен быть строкой' })
+  @MaxLength(120, { message: 'Статус доставки должен содержать не более 120 символов' })
+  shippingStatus?: string;
+
+  @ApiPropertyOptional({ example: 'Позвонить перед доставкой', description: 'Комментарий менеджера' })
+  @IsOptional()
+  @IsString({ message: 'Комментарий должен быть строкой' })
+  comment?: string;
+
+  @ApiPropertyOptional({ example: 5, description: 'Идентификатор адреса доставки' })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt({ message: 'Идентификатор адреса должен быть целым числом' })
+  @IsPositive({ message: 'Идентификатор адреса должен быть положительным' })
+  addressId?: number;
+}

--- a/backend/src/modules/orders/dto/order-customer.dto.ts
+++ b/backend/src/modules/orders/dto/order-customer.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+// dto representing a lightweight customer entry for managers
+export class OrderCustomerDto {
+  @ApiProperty({ example: 7, description: 'Идентификатор пользователя' })
+  id: number;
+
+  @ApiProperty({ example: 'Сид Уилсон', description: 'Имя покупателя' })
+  name: string;
+
+  @ApiProperty({ example: 'sid@slipknot.com', description: 'Электронная почта покупателя' })
+  email: string;
+}

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -1,6 +1,8 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -10,6 +12,8 @@ import {
 import { OrdersService } from './orders.service';
 import { OrderResponseDto } from './dto/order-response.dto';
 import { UpdateOrderDto } from './dto/update-order.dto';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { OrderCustomerDto } from './dto/order-customer.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -23,11 +27,26 @@ import { Roles } from '../auth/roles.decorator';
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
+  @Post()
+  @ApiOperation({ summary: 'Создать новый заказ' })
+  @ApiCreatedResponse({ description: 'Заказ создан', type: OrderResponseDto })
+  @ApiBadRequestResponse({ description: 'Некорректные данные заказа' })
+  create(@Body() createOrderDto: CreateOrderDto): Promise<OrderResponseDto> {
+    return this.ordersService.create(createOrderDto);
+  }
+
   @Get()
   @ApiOperation({ summary: 'Получить список заказов' })
   @ApiOkResponse({ description: 'Список заказов', type: OrderResponseDto, isArray: true })
   findAll(): Promise<OrderResponseDto[]> {
     return this.ordersService.findAll();
+  }
+
+  @Get('customers')
+  @ApiOperation({ summary: 'Получить список покупателей' })
+  @ApiOkResponse({ description: 'Покупатели для выбора при создании заказа', type: OrderCustomerDto, isArray: true })
+  findCustomers(): Promise<OrderCustomerDto[]> {
+    return this.ordersService.findCustomers();
   }
 
   @Get(':id')

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -4,11 +4,13 @@ import { Order } from './entities/order.entity';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
 import { OrderStatus } from '../order-statuses/entities/order-status.entity';
+import { User } from '../users/entities/user.entity';
+import { UserAddress } from '../user-addresses/entities/user-address.entity';
 import { CustomerOrdersController } from './customer-orders.controller';
 
 // module wiring for order management
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderStatus])],
+  imports: [TypeOrmModule.forFeature([Order, OrderStatus, User, UserAddress])],
   controllers: [OrdersController, CustomerOrdersController],
   providers: [OrdersService],
   exports: [OrdersService],

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   Param,
   ParseIntPipe,
+  Post,
   Put,
   Req,
   UnauthorizedException,
@@ -13,6 +14,8 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -28,6 +31,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserResponseDto, UserRoleDto } from './dto/user-response.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { CreateUserDto } from './dto/create-user.dto';
 import { UsersService } from './users.service';
 
 type RequestWithUser = Request & { user?: { userId?: number } };
@@ -37,6 +41,18 @@ type RequestWithUser = Request & { user?: { userId?: number } };
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('Администратор')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Создать нового пользователя' })
+  @ApiCreatedResponse({ description: 'Пользователь создан', type: UserResponseDto })
+  @ApiBadRequestResponse({ description: 'Некорректные данные пользователя' })
+  @ApiForbiddenResponse({ description: 'Доступ запрещён' })
+  async createUser(@Body() dto: CreateUserDto): Promise<UserResponseDto> {
+    return this.usersService.create(dto);
+  }
 
   @Get('me')
   @UseGuards(JwtAuthGuard)

--- a/frontend/src/api/orders.ts
+++ b/frontend/src/api/orders.ts
@@ -45,12 +45,28 @@ export interface OrderStatusDto {
   name: string;
 }
 
+export interface OrderCustomerDto {
+  id: number;
+  name: string;
+  email: string;
+}
+
 export interface UpdateOrderPayload {
   statusId?: number;
   totalAmount?: number;
   paymentMethod?: string;
   comment?: string;
   shippingStatus?: string;
+}
+
+export interface CreateOrderPayload {
+  userId: number;
+  statusId: number;
+  totalAmount: number;
+  paymentMethod?: string;
+  comment?: string;
+  shippingStatus?: string;
+  addressId?: number;
 }
 
 export const fetchOrders = async (): Promise<OrderDto[]> => {
@@ -60,6 +76,16 @@ export const fetchOrders = async (): Promise<OrderDto[]> => {
 
 export const fetchOrderStatuses = async (): Promise<OrderStatusDto[]> => {
   const { data } = await http.get<OrderStatusDto[]>('/order-statuses');
+  return data;
+};
+
+export const fetchOrderCustomers = async (): Promise<OrderCustomerDto[]> => {
+  const { data } = await http.get<OrderCustomerDto[]>('/orders/customers');
+  return data;
+};
+
+export const createOrder = async (payload: CreateOrderPayload): Promise<OrderDto> => {
+  const { data } = await http.post<OrderDto>('/orders', payload);
   return data;
 };
 

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -45,6 +45,22 @@ export interface UpdateProductPayload {
   sizeId?: number | null;
 }
 
+export interface CreateProductPayload {
+  title: string;
+  description?: string;
+  price: number;
+  sku: string;
+  stockCount: number;
+  imageUrl?: string;
+  categoryId: number;
+  sizeId?: number | null;
+}
+
+export const createProduct = async (payload: CreateProductPayload): Promise<ProductDto> => {
+  const { data } = await http.post<ProductDto>('/products', payload);
+  return data;
+};
+
 export const updateProduct = async (
   id: number,
   payload: UpdateProductPayload,

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -30,6 +30,17 @@ export interface UpdateUserPayload {
   address?: string;
 }
 
+export interface CreateUserPayload {
+  name: string;
+  email: string;
+  password: string;
+  phone?: string;
+  roleName?: string;
+  country?: string;
+  city?: string;
+  address?: string;
+}
+
 export interface UpdateProfilePayload {
   name?: string;
   email?: string;
@@ -57,6 +68,11 @@ export const fetchRoles = async (): Promise<UserRole[]> => {
 
 export const updateUser = async (id: number, payload: UpdateUserPayload): Promise<UserListItem> => {
   const { data } = await http.put<UserListItem>(`/users/${id}`, payload);
+  return data;
+};
+
+export const createUser = async (payload: CreateUserPayload): Promise<UserListItem> => {
+  const { data } = await http.post<UserListItem>('/users', payload);
   return data;
 };
 

--- a/frontend/src/pages/ManagerPage.vue
+++ b/frontend/src/pages/ManagerPage.vue
@@ -18,9 +18,14 @@
         <section class="manager-block">
           <div class="manager-block__header">
             <h2 class="manager-block__title">Товары</h2>
-            <button class="btn btn-outline-secondary" @click="refreshProducts" :disabled="productsLoading">
-              Обновить список
-            </button>
+            <div class="manager-block__actions">
+              <button class="btn btn-outline-secondary" @click="refreshProducts" :disabled="productsLoading">
+                Обновить список
+              </button>
+              <button class="btn btn-primary" type="button" @click="openAddProductModal">
+                Добавить товар
+              </button>
+            </div>
           </div>
           <div class="table-responsive">
             <table class="table align-middle mb-0 manager-table">
@@ -172,9 +177,14 @@
         <section class="manager-block">
           <div class="manager-block__header">
             <h2 class="manager-block__title">Заказы</h2>
-            <button class="btn btn-outline-secondary" @click="refreshOrders" :disabled="ordersLoading">
-              Обновить список
-            </button>
+            <div class="manager-block__actions">
+              <button class="btn btn-outline-secondary" @click="refreshOrders" :disabled="ordersLoading">
+                Обновить список
+              </button>
+              <button class="btn btn-primary" type="button" @click="openAddOrderModal">
+                Добавить заказ
+              </button>
+            </div>
           </div>
           <div class="table-responsive">
             <table class="table align-middle mb-0 manager-table">
@@ -300,16 +310,272 @@
       </div>
     </div>
   </section>
+
+  <div v-if="addProductModalVisible" class="modal fade show d-block glass-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title h5 mb-0">Новый товар</h2>
+          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeAddProductModal"></button>
+        </div>
+        <form @submit.prevent="saveNewProduct">
+          <div class="modal-body">
+            <p class="modal-subtitle text-muted">
+              Заполните карточку товара. Все поля можно отредактировать в любой момент.
+            </p>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="newProductTitle" class="form-label">Название</label>
+                <input
+                  id="newProductTitle"
+                  v-model="addProductForm.title"
+                  type="text"
+                  class="form-control"
+                  placeholder="Например, Толстовка Slipknot"
+                  required
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="col-md-6">
+                <label for="newProductSku" class="form-label">Артикул</label>
+                <input
+                  id="newProductSku"
+                  v-model="addProductForm.sku"
+                  type="text"
+                  class="form-control"
+                  placeholder="SKU-001"
+                  required
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="col-md-4">
+                <label for="newProductPrice" class="form-label">Цена (₽)</label>
+                <input
+                  id="newProductPrice"
+                  v-model="addProductForm.price"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  class="form-control"
+                  required
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="col-md-4">
+                <label for="newProductStock" class="form-label">Остаток</label>
+                <input
+                  id="newProductStock"
+                  v-model="addProductForm.stockCount"
+                  type="number"
+                  min="0"
+                  class="form-control"
+                  required
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="col-md-4">
+                <label for="newProductCategory" class="form-label">Категория</label>
+                <select
+                  id="newProductCategory"
+                  v-model="addProductForm.categoryId"
+                  class="form-select"
+                  required
+                  :disabled="creatingProduct"
+                >
+                  <option value="">Выберите категорию</option>
+                  <option v-for="category in categories" :key="category.id" :value="String(category.id)">
+                    {{ category.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="col-md-4">
+                <label for="newProductSize" class="form-label">Размер</label>
+                <select
+                  id="newProductSize"
+                  v-model="addProductForm.sizeId"
+                  class="form-select"
+                  :disabled="creatingProduct"
+                >
+                  <option value="">Без размера</option>
+                  <option v-for="size in sizes" :key="size.id" :value="String(size.id)">
+                    {{ size.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="col-md-8">
+                <label for="newProductImage" class="form-label">Ссылка на изображение</label>
+                <input
+                  id="newProductImage"
+                  v-model="addProductForm.imageUrl"
+                  type="url"
+                  class="form-control"
+                  placeholder="https://"
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="col-12">
+                <label for="newProductDescription" class="form-label">Описание</label>
+                <textarea
+                  id="newProductDescription"
+                  v-model="addProductForm.description"
+                  class="form-control"
+                  rows="3"
+                  placeholder="Коротко опишите товар"
+                  :disabled="creatingProduct"
+                ></textarea>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer modal-footer--stacked">
+            <button type="button" class="btn btn-outline-secondary" @click="closeAddProductModal" :disabled="creatingProduct">
+              Отмена
+            </button>
+            <button type="submit" class="btn btn-primary" :disabled="creatingProduct">
+              Сохранить
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div v-if="addProductModalVisible" class="modal-backdrop fade show"></div>
+
+  <div v-if="addOrderModalVisible" class="modal fade show d-block glass-modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 class="modal-title h5 mb-0">Новый заказ</h2>
+          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeAddOrderModal"></button>
+        </div>
+        <form @submit.prevent="saveNewOrder">
+          <div class="modal-body">
+            <p class="modal-subtitle text-muted">
+              Создайте новый заказ и зафиксируйте ключевые данные клиента и доставки.
+            </p>
+            <div class="row g-3">
+              <div class="col-md-6">
+                <label for="newOrderUser" class="form-label">Покупатель</label>
+                <select
+                  id="newOrderUser"
+                  v-model="addOrderForm.userId"
+                  class="form-select"
+                  required
+                  :disabled="creatingOrder || !orderCustomers.length"
+                >
+                  <option value="">Выберите покупателя</option>
+                  <option v-for="customer in orderCustomers" :key="customer.id" :value="String(customer.id)">
+                    {{ customer.name }} • {{ customer.email }}
+                  </option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="newOrderStatus" class="form-label">Статус</label>
+                <select
+                  id="newOrderStatus"
+                  v-model="addOrderForm.statusId"
+                  class="form-select"
+                  required
+                  :disabled="creatingOrder"
+                >
+                  <option value="">Выберите статус</option>
+                  <option v-for="status in orderStatuses" :key="status.id" :value="String(status.id)">
+                    {{ status.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="newOrderShipping" class="form-label">Статус отправки</label>
+                <select
+                  id="newOrderShipping"
+                  v-model="addOrderForm.shippingStatus"
+                  class="form-select"
+                  required
+                  :disabled="creatingOrder"
+                >
+                  <option v-for="option in shippingStatusOptions" :key="option" :value="option">
+                    {{ option }}
+                  </option>
+                </select>
+              </div>
+              <div class="col-md-6">
+                <label for="newOrderTotal" class="form-label">Сумма (₽)</label>
+                <input
+                  id="newOrderTotal"
+                  v-model="addOrderForm.totalAmount"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  class="form-control"
+                  required
+                  :disabled="creatingOrder"
+                />
+              </div>
+              <div class="col-md-6">
+                <label for="newOrderPayment" class="form-label">Способ оплаты</label>
+                <input
+                  id="newOrderPayment"
+                  v-model="addOrderForm.paymentMethod"
+                  type="text"
+                  class="form-control"
+                  placeholder="Например, Банковская карта"
+                  :disabled="creatingOrder"
+                />
+              </div>
+              <div class="col-md-6">
+                <label for="newOrderAddress" class="form-label">ID адреса (опционально)</label>
+                <input
+                  id="newOrderAddress"
+                  v-model="addOrderForm.addressId"
+                  type="number"
+                  min="1"
+                  class="form-control"
+                  placeholder="Укажите при необходимости"
+                  :disabled="creatingOrder"
+                />
+              </div>
+              <div class="col-12">
+                <label for="newOrderComment" class="form-label">Комментарий</label>
+                <textarea
+                  id="newOrderComment"
+                  v-model="addOrderForm.comment"
+                  class="form-control"
+                  rows="3"
+                  placeholder="Дополнительная информация для сборки или доставки"
+                  :disabled="creatingOrder"
+                ></textarea>
+              </div>
+              <div v-if="!orderCustomers.length" class="col-12">
+                <div class="manager-modal__empty">
+                  Нет доступных покупателей. Добавьте пользователя в разделе администрирования.
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer modal-footer--stacked">
+            <button type="button" class="btn btn-outline-secondary" @click="closeAddOrderModal" :disabled="creatingOrder">
+              Отмена
+            </button>
+            <button type="submit" class="btn btn-primary" :disabled="creatingOrder || !orderCustomers.length">
+              Сохранить
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div v-if="addOrderModalVisible" class="modal-backdrop fade show"></div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import {
   fetchProducts,
+  createProduct,
   updateProduct,
   deleteProduct,
   type ProductDto,
+  type CreateProductPayload,
   type UpdateProductPayload,
 } from '../api/products';
 import { fetchCategories, type CategoryDto } from '../api/categories';
@@ -317,16 +583,31 @@ import { fetchSizes, type SizeDto } from '../api/sizes';
 import {
   fetchOrders,
   fetchOrderStatuses,
+  fetchOrderCustomers,
+  createOrder,
   updateOrder,
   deleteOrder,
   type OrderDto,
   type OrderStatusDto,
+  type OrderCustomerDto,
+  type CreateOrderPayload,
   type UpdateOrderPayload,
 } from '../api/orders';
 import { extractErrorMessage } from '../api/http';
 
 interface ProductFormState {
   id: number;
+  title: string;
+  description: string;
+  price: string;
+  sku: string;
+  stockCount: string;
+  imageUrl: string;
+  categoryId: string;
+  sizeId: string;
+}
+
+interface NewProductFormState {
   title: string;
   description: string;
   price: string;
@@ -346,11 +627,22 @@ interface OrderFormState {
   comment: string;
 }
 
+interface NewOrderFormState {
+  userId: string;
+  statusId: string;
+  shippingStatus: string;
+  totalAmount: string;
+  paymentMethod: string;
+  comment: string;
+  addressId: string;
+}
+
 const products = ref<ProductDto[]>([]);
 const orders = ref<OrderDto[]>([]);
 const categories = ref<CategoryDto[]>([]);
 const sizes = ref<SizeDto[]>([]);
 const orderStatuses = ref<OrderStatusDto[]>([]);
+const orderCustomers = ref<OrderCustomerDto[]>([]);
 const shippingStatusOptions = ref<string[]>(['Готовится к отправке', 'В пути', 'Доставлен']);
 
 const initialLoading = ref(false);
@@ -358,12 +650,35 @@ const productsLoading = ref(false);
 const ordersLoading = ref(false);
 const productSaving = ref(false);
 const orderSaving = ref(false);
+const creatingProduct = ref(false);
+const creatingOrder = ref(false);
 
 const globalError = ref<string | null>(null);
 const successMessage = ref<string | null>(null);
 
 const productForm = ref<ProductFormState | null>(null);
 const orderForm = ref<OrderFormState | null>(null);
+const addProductModalVisible = ref(false);
+const addOrderModalVisible = ref(false);
+const addProductForm = reactive<NewProductFormState>({
+  title: '',
+  description: '',
+  price: '',
+  sku: '',
+  stockCount: '',
+  imageUrl: '',
+  categoryId: '',
+  sizeId: '',
+});
+const addOrderForm = reactive<NewOrderFormState>({
+  userId: '',
+  statusId: '',
+  shippingStatus: shippingStatusOptions.value[0] ?? 'Готовится к отправке',
+  totalAmount: '',
+  paymentMethod: '',
+  comment: '',
+  addressId: '',
+});
 
 const formatCurrency = (value: number) => {
   return new Intl.NumberFormat('ru-RU', {
@@ -397,23 +712,102 @@ const showSuccess = (message: string) => {
   globalError.value = null;
 };
 
+const getDefaultShippingStatus = () => shippingStatusOptions.value[0] ?? 'Готовится к отправке';
+const getDefaultStatusId = () => (orderStatuses.value.length ? String(orderStatuses.value[0].id) : '');
+
+const resetAddProductForm = () => {
+  Object.assign(addProductForm, {
+    title: '',
+    description: '',
+    price: '',
+    sku: '',
+    stockCount: '',
+    imageUrl: '',
+    categoryId: '',
+    sizeId: '',
+  });
+};
+
+const resetAddOrderForm = () => {
+  Object.assign(addOrderForm, {
+    userId: '',
+    statusId: getDefaultStatusId(),
+    shippingStatus: getDefaultShippingStatus(),
+    totalAmount: '',
+    paymentMethod: '',
+    comment: '',
+    addressId: '',
+  });
+};
+
+const toggleAddProductModal = (visible: boolean) => {
+  if (visible) {
+    resetAddProductForm();
+  }
+  addProductModalVisible.value = visible;
+};
+
+const toggleAddOrderModal = (visible: boolean) => {
+  if (visible) {
+    resetAddOrderForm();
+  }
+  addOrderModalVisible.value = visible;
+};
+
+const refreshOrderCustomers = async (silent = false) => {
+  try {
+    orderCustomers.value = await fetchOrderCustomers();
+  } catch (error) {
+    if (!silent) {
+      showError(error);
+    }
+  }
+};
+
+const openAddProductModal = () => {
+  toggleAddProductModal(true);
+};
+
+const closeAddProductModal = () => {
+  toggleAddProductModal(false);
+};
+
+const openAddOrderModal = () => {
+  toggleAddOrderModal(true);
+  void refreshOrderCustomers(true);
+};
+
+const closeAddOrderModal = () => {
+  toggleAddOrderModal(false);
+};
+
 const loadInitialData = async () => {
   try {
     initialLoading.value = true;
     globalError.value = null;
-    const [productsData, ordersData, categoriesData, sizesData, statusesData] = await Promise.all([
+    const [
+      productsData,
+      ordersData,
+      categoriesData,
+      sizesData,
+      statusesData,
+      customersData,
+    ] = await Promise.all([
       fetchProducts(),
       fetchOrders(),
       fetchCategories(),
       fetchSizes(),
       fetchOrderStatuses(),
+      fetchOrderCustomers(),
     ]);
     products.value = productsData;
     orders.value = ordersData;
     categories.value = categoriesData;
     sizes.value = sizesData;
     orderStatuses.value = statusesData;
+    orderCustomers.value = customersData;
     orders.value.forEach((order) => ensureShippingStatusOption(order.shippingStatus));
+    resetAddOrderForm();
   } catch (error) {
     showError(error);
   } finally {
@@ -439,6 +833,7 @@ const refreshOrders = async () => {
     orders.value = await fetchOrders();
     orders.value.forEach((order) => ensureShippingStatusOption(order.shippingStatus));
     showSuccess('Список заказов обновлён.');
+    await refreshOrderCustomers(true);
   } catch (error) {
     showError(error);
   } finally {
@@ -462,6 +857,40 @@ const startEditProduct = (product: ProductDto) => {
 
 const cancelProductEdit = () => {
   productForm.value = null;
+};
+
+const saveNewProduct = async () => {
+  if (
+    !addProductForm.title ||
+    !addProductForm.sku ||
+    !addProductForm.price ||
+    !addProductForm.stockCount ||
+    !addProductForm.categoryId
+  ) {
+    return;
+  }
+
+  try {
+    creatingProduct.value = true;
+    const payload: CreateProductPayload = {
+      title: addProductForm.title,
+      description: addProductForm.description ? addProductForm.description : undefined,
+      price: Number(addProductForm.price),
+      sku: addProductForm.sku,
+      stockCount: Number(addProductForm.stockCount),
+      imageUrl: addProductForm.imageUrl ? addProductForm.imageUrl : undefined,
+      categoryId: Number(addProductForm.categoryId),
+      sizeId: addProductForm.sizeId ? Number(addProductForm.sizeId) : undefined,
+    };
+    await createProduct(payload);
+    products.value = await fetchProducts();
+    showSuccess('Новый товар добавлен.');
+    toggleAddProductModal(false);
+  } catch (error) {
+    showError(error);
+  } finally {
+    creatingProduct.value = false;
+  }
 };
 
 const saveProduct = async () => {
@@ -514,6 +943,35 @@ const startEditOrder = (order: OrderDto) => {
 
 const cancelOrderEdit = () => {
   orderForm.value = null;
+};
+
+const saveNewOrder = async () => {
+  if (!addOrderForm.userId || !addOrderForm.statusId || addOrderForm.totalAmount === '') {
+    return;
+  }
+
+  try {
+    creatingOrder.value = true;
+    const payload: CreateOrderPayload = {
+      userId: Number(addOrderForm.userId),
+      statusId: Number(addOrderForm.statusId),
+      totalAmount: Number(addOrderForm.totalAmount),
+      paymentMethod: addOrderForm.paymentMethod ? addOrderForm.paymentMethod : undefined,
+      comment: addOrderForm.comment ? addOrderForm.comment : undefined,
+      shippingStatus: addOrderForm.shippingStatus ? addOrderForm.shippingStatus : undefined,
+      addressId: addOrderForm.addressId ? Number(addOrderForm.addressId) : undefined,
+    };
+    const createdOrder = await createOrder(payload);
+    ensureShippingStatusOption(createdOrder.shippingStatus);
+    orders.value = await fetchOrders();
+    orders.value.forEach((order) => ensureShippingStatusOption(order.shippingStatus));
+    showSuccess('Заказ создан.');
+    toggleAddOrderModal(false);
+  } catch (error) {
+    showError(error);
+  } finally {
+    creatingOrder.value = false;
+  }
 };
 
 const saveOrder = async () => {
@@ -593,6 +1051,14 @@ onMounted(() => {
   flex-wrap: wrap;
 }
 
+.manager-block__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .manager-block__title {
   margin: 0;
   font-size: 1.6rem;
@@ -654,6 +1120,15 @@ onMounted(() => {
   margin: 0;
   font-size: 1.3rem;
   font-weight: 600;
+}
+
+.manager-modal__empty {
+  padding: 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px dashed color-mix(in srgb, var(--color-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  color: var(--color-text-muted);
+  text-align: center;
 }
 
 @media (max-width: 575.98px) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -199,7 +199,6 @@ select {
   white-space: nowrap;
 }
 
-.navbar .nav-link,
 .navbar .btn {
   white-space: nowrap;
 }
@@ -212,7 +211,16 @@ select {
   color: var(--color-text-muted);
   font-weight: 500;
   border-radius: var(--radius-lg);
-  padding: 0.55rem 1rem;
+  padding: 0.65rem 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  text-align: center;
+  white-space: normal;
+  text-wrap: balance;
+  line-height: 1.2;
+  min-height: 2.6rem;
   transition: color var(--transition-base), background-color var(--transition-base),
     box-shadow var(--transition-base), transform var(--transition-base);
 }
@@ -248,6 +256,14 @@ select {
 .navbar .btn,
 .navbar .theme-toggle {
   margin-left: 0.5rem;
+}
+
+.navbar .theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6rem;
+  white-space: nowrap;
 }
 
 .btn {
@@ -434,16 +450,95 @@ textarea {
   border-color: color-mix(in srgb, var(--color-surface-border) 65%, transparent) !important;
 }
 
+.glass-modal .modal-dialog {
+  animation: glassModalIn 0.38s ease forwards;
+  will-change: transform, opacity;
+}
+
 .glass-modal .modal-content {
-  background: color-mix(in srgb, var(--color-surface-strong) 92%, transparent);
-  border: 1px solid var(--color-surface-border);
-  box-shadow: var(--shadow-hover);
+  position: relative;
+  background: linear-gradient(
+      155deg,
+      color-mix(in srgb, var(--color-surface-strong) 94%, transparent),
+      color-mix(in srgb, var(--color-surface) 82%, transparent)
+    );
+  border: 1px solid color-mix(in srgb, var(--color-surface-border) 72%, transparent);
+  box-shadow: 0 28px 48px rgba(8, 12, 20, 0.32), var(--shadow-hover);
   backdrop-filter: blur(var(--blur-radius));
+}
+
+.glass-modal .modal-content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(
+    circle at top right,
+    color-mix(in srgb, var(--color-accent) 22%, transparent) 0%,
+    transparent 60%
+  );
+  opacity: 0.55;
+}
+
+.glass-modal .modal-content::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-surface-border) 35%, transparent),
+    inset 0 18px 48px rgba(255, 255, 255, 0.04);
 }
 
 .glass-modal .modal-header,
 .glass-modal .modal-footer {
-  border-color: color-mix(in srgb, var(--color-surface-border) 45%, transparent) !important;
+  border-color: color-mix(in srgb, var(--color-surface-border) 38%, transparent) !important;
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+}
+
+.glass-modal .modal-body {
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  border-radius: calc(var(--radius-lg) * 0.8);
+}
+
+.modal-subtitle {
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.modal-footer--stacked {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.modal-footer--stacked .btn {
+  min-width: 8.5rem;
+}
+
+@keyframes glassModalIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .modal-footer--stacked {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .modal-footer--stacked .btn {
+    width: 100%;
+  }
 }
 
 .table-hover > tbody > tr:hover {


### PR DESCRIPTION
## Summary
- реализовал DTO и эндпоинты для создания заказов и выдачи покупателей менеджеру, а также POST для создания пользователей админом
- добавил на панели менеджера и администратора кнопки «Добавить…» с модальными формами, использующими новые API вызовы
- доработал глобальные стили: стеклянные модалки и адаптивное перенесение пунктов навигации без смещения переключателя темы

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68edea275f048321bd36c89b33728201