### PR TITLE
Fix profile page profile loading

### DIFF
--- a/Tasks/TASK_17_profile-load-fix.MD
+++ b/Tasks/TASK_17_profile-load-fix.MD
@@ -1,0 +1,12 @@
+# TASK_17_profile-load-fix
+
+## Что было сделано
+Исправил обращение к несуществующему методу `fetchProfile` на странице профиля, чтобы профиль корректно подгружался через `loadProfile` из Pinia стора.
+
+## Изменения
+- `frontend/src/pages/ProfilePage.vue` — заменил вызовы `authStore.fetchProfile()` на `authStore.loadProfile()` для инициализации и ручного обновления данных профиля.
+
+## Проверка
+1. Запустить бэкенд: `cd backend && npm run start:dev` (требуется активная БД PostgreSQL).
+2. Запустить фронтенд: `cd frontend && npm run dev -- --host 0.0.0.0 --port 5173`.
+3. Открыть `http://localhost:5173/profile` и убедиться, что данные профиля загружаются без ошибок.

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -206,7 +206,7 @@ const canSubmit = computed(() => form.name.trim().length >= 2 && form.email.trim
 const refreshProfile = () => {
   localError.value = null;
   successMessage.value = '';
-  void authStore.fetchProfile();
+  void authStore.loadProfile();
 };
 
 const toggleCityInput = () => {
@@ -262,7 +262,7 @@ watch(error, (value) => {
 
 onMounted(() => {
   if (!user.value) {
-    void authStore.fetchProfile();
+    void authStore.loadProfile();
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- replace profile page calls to the nonexistent `fetchProfile` store method with the exported `loadProfile`
- log the update in `Tasks/TASK_17_profile-load-fix.MD`

## Testing
- npm run start:dev *(fails: PostgreSQL is not running in the execution environment)*
- npm run dev -- --host 0.0.0.0 --port 5173


------
https://chatgpt.com/codex/tasks/task_e_68ee0213529483219b12cd64db2bf49c