### PR TITLE
Fix auth flow and catalog logging

### DIFF
--- a/Tasks/TASK_18_auth-catalog-fixes.MD
+++ b/Tasks/TASK_18_auth-catalog-fixes.MD
@@ -1,0 +1,18 @@
+# TASK_18_auth-catalog-fixes
+
+## Что было сделано
+- Настроено подключение к PostgreSQL и обновлён скрипт schema.sql с тестовыми пользователями и товарами.
+- Добавлено подробное логирование на NestJS: глобальные HTTP-запросы, подключение к БД и ошибки аутентификации/каталога.
+- Исправлены проблемы входа/регистрации и загрузки каталога, проверена работа фронтенда.
+
+## Изменения
+- backend/.env — параметры подключения к локальной БД и JWT-секреты.
+- backend/src/main.ts, backend/src/common/interceptors/request-logging.interceptor.ts — глобальное логирование и проверка подключения к БД.
+- backend/src/modules/auth/auth.service.ts — логирование сценариев регистрации/авторизации.
+- backend/src/modules/products/products.service.ts — логирование загрузки каталога.
+- backend/database/schema.sql — тестовые записи ролей, пользователей и товаров.
+
+## Проверка
+- Backend: `cd backend && npm run start:dev`
+- Frontend: `cd frontend && npm run dev -- --host 0.0.0.0 --port 5174`
+- Ручные проверки: регистрация, авторизация и загрузка каталога через UI и curl.

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -164,6 +164,40 @@ INSERT INTO order_statuses (name) VALUES
     ('Отменен')
 ON CONFLICT (name) DO NOTHING;
 
+INSERT INTO users (name, email, password_hash, phone, country, city, address, role_id)
+VALUES
+    (
+        'Алексей Админ',
+        'admin@slipknot-shop.ru',
+        '$2b$10$W7sSfO96GfWMYdBTtJR70Oy7/ayMYbg7K4Y3QxcJ2DsbSxhVhoGQi',
+        '+7 (900) 100-00-01',
+        'Россия',
+        'Москва',
+        'ул. Арбат, д. 1',
+        (SELECT id FROM roles WHERE name = 'Администратор')
+    ),
+    (
+        'Мария Менеджер',
+        'manager@slipknot-shop.ru',
+        '$2b$10$XHwr1ItKuGuYL7D/zHROMOc4bYpNbv/yaIP6JNVtkuDqfWuN9/47O',
+        '+7 (901) 200-00-02',
+        'Россия',
+        'Санкт-Петербург',
+        'Невский проспект, д. 10',
+        (SELECT id FROM roles WHERE name = 'Менеджер')
+    ),
+    (
+        'Иван Покупатель',
+        'customer@slipknot-shop.ru',
+        '$2b$10$EbCqo2VQSRRy0npX/JelO./ShlsIuXIDY5cihK0fnbjeQuUJp8hsm',
+        '+7 (902) 300-00-03',
+        'Россия',
+        'Екатеринбург',
+        'ул. Ленина, д. 25',
+        (SELECT id FROM roles WHERE name = 'Покупатель')
+    )
+ON CONFLICT (email) DO NOTHING;
+
 WITH product_data AS (
     SELECT
         'SKU-TSHIRT-001'::text AS sku,

--- a/backend/src/common/interceptors/request-logging.interceptor.ts
+++ b/backend/src/common/interceptors/request-logging.interceptor.ts
@@ -1,0 +1,35 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor, Logger } from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { Request, Response } from 'express';
+
+// interceptor that logs every incoming HTTP request and response
+@Injectable()
+export class RequestLoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger('HTTP');
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const httpContext = context.switchToHttp();
+    const request = httpContext.getRequest<Request>();
+    const { method, originalUrl } = request;
+    const startedAt = Date.now();
+
+    this.logger.log(`➡️  ${method} ${originalUrl}`);
+
+    return next.handle().pipe(
+      tap(() => {
+        const response = httpContext.getResponse<Response>();
+        const statusCode = response.statusCode;
+        const duration = Date.now() - startedAt;
+        this.logger.log(`⬅️  ${method} ${originalUrl} ${statusCode} +${duration}ms`);
+      }),
+      catchError((error) => {
+        const duration = Date.now() - startedAt;
+        const statusCode = (error && (error.status || error.statusCode)) ?? 500;
+        const message = error?.message ?? 'Internal server error';
+        this.logger.error(`💥 ${method} ${originalUrl} ${statusCode} +${duration}ms :: ${message}`, error?.stack);
+        return throwError(() => error);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a global request logging interceptor and database connection reporting in NestJS bootstrap
- extend auth and catalog services with structured logging and seed demo users in the schema
- document the verification steps for the task in Tasks/TASK_18_auth-catalog-fixes.MD

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5174 --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68ee0743dda08321b8bffb076efa20b5