### PR TITLE
Fix reactive auth navigation

### DIFF
--- a/Tasks/TASK_19_auth-routing-fix.MD
+++ b/Tasks/TASK_19_auth-routing-fix.MD
@@ -1,0 +1,20 @@
+# TASK_19_auth-routing-fix
+
+## Что было сделано
+- Исправлена реактивность авторизации и синхронизация токенов, добавлены логи навигации и состояния.
+- Обновлена логика редиректов после входа/регистрации/выхода и перерисовка страниц без перезагрузки.
+- Устранены ошибки типизации в API корзины и пользователей, обновлена логика оплаты заказа во фронтенде.
+
+## Изменения
+- frontend/src/store/authStore.ts
+- frontend/src/store/cartStore.ts
+- frontend/src/router/index.ts
+- frontend/src/components/AppNavbar.vue
+- frontend/src/pages/AuthPage.vue
+- frontend/src/api/users.ts
+- frontend/src/api/cart.ts
+- frontend/src/App.vue
+- frontend/src/pages/CheckoutPaymentPage.vue
+
+## Проверка
+- Установить зависимости и собрать фронтенд: `cd frontend && npm install && npm run build`.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,9 +3,9 @@
     <div class="app-shell fade-in-up">
       <AppNavbar />
       <main class="app-main">
-        <RouterView v-slot="{ Component }">
+        <RouterView v-slot="{ Component, route }">
           <Transition name="page" mode="out-in">
-            <component :is="Component" />
+            <component :is="Component" :key="route.fullPath" />
           </Transition>
         </RouterView>
       </main>

--- a/frontend/src/api/cart.ts
+++ b/frontend/src/api/cart.ts
@@ -35,6 +35,7 @@ export interface CheckoutResponse {
   totalAmount: number;
   shippingStatus: string;
   shippingUpdatedAt: string;
+  paidAt?: string | null;
 }
 
 export const fetchCart = async (): Promise<CartResponse> => {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -23,7 +23,7 @@ export interface UserListItem extends UserProfile {}
 export interface UpdateUserPayload {
   name: string;
   email: string;
-  phone: string;
+  phone?: string | null;
   roleName: string;
   country?: string;
   city?: string;

--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -70,6 +70,6 @@ const closeModal = () => {
 const handleLogout = async () => {
   authStore.logout();
   closeModal();
-  await router.push('/');
+  await router.replace({ name: 'login', query: { message: 'Вы успешно вышли из аккаунта' } });
 };
 </script>

--- a/frontend/src/pages/AuthPage.vue
+++ b/frontend/src/pages/AuthPage.vue
@@ -87,12 +87,20 @@ const form = reactive({
   phone: '',
 });
 
+const resolveRedirect = () => {
+  const redirectTarget = route.query.redirect;
+  if (typeof redirectTarget === 'string' && redirectTarget.startsWith('/')) {
+    return redirectTarget;
+  }
+  return '/profile';
+};
+
 const handleSubmit = async () => {
   try {
     if (mode.value === 'login') {
       await authStore.loginUser({ email: form.email, password: form.password });
       success.value = 'Вход выполнен успешно!';
-      await router.push('/');
+      await router.replace(resolveRedirect());
     } else {
       await authStore.registerUser({
         name: form.name,
@@ -101,7 +109,7 @@ const handleSubmit = async () => {
         phone: form.phone || undefined,
       });
       success.value = 'Аккаунт создан! Добро пожаловать.';
-      await router.push('/');
+      await router.replace(resolveRedirect());
     }
   } catch (err) {
     console.error('Auth request failed', err);

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -67,6 +67,7 @@ export const router = createRouter({
 });
 
 router.beforeEach(async (to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) => {
+  console.info('Navigating to', to.name ?? to.fullPath);
   const requiresAuth = to.matched.some((route) => route.meta?.requiresAuth);
   if (!requiresAuth) {
     return next();
@@ -100,4 +101,8 @@ router.beforeEach(async (to: RouteLocationNormalized, _from: RouteLocationNormal
   }
 
   return next();
+});
+
+router.afterEach((to) => {
+  console.info('Navigation finished', to.name ?? to.fullPath);
 });

--- a/frontend/src/store/cartStore.ts
+++ b/frontend/src/store/cartStore.ts
@@ -1,5 +1,5 @@
 import { defineStore, storeToRefs } from 'pinia';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
   addCartItem,
   checkoutCart,
@@ -147,9 +147,22 @@ export const useCartStore = defineStore('cart', () => {
     return result;
   };
 
-  if (localStorage.getItem('accessToken')) {
-    void loadCart();
-  }
+  const payOrder = async (): Promise<CheckoutResponse | null> => {
+    return checkout();
+  };
+
+  watch(
+    isAuthenticated,
+    (loggedIn) => {
+      if (loggedIn) {
+        void loadCart();
+        return;
+      }
+      resetCart();
+      lastOrder.value = null;
+    },
+    { immediate: true }
+  );
 
   return {
     cartId,
@@ -166,5 +179,6 @@ export const useCartStore = defineStore('cart', () => {
     changeItemQuantity,
     removeItem,
     checkout,
+    payOrder,
   };
 });


### PR DESCRIPTION
## Summary
- ensure router transitions trigger re-renders and log navigation events
- make the auth store sync tokens, emit state logs, and redirect after login/logout
- refresh cart state when auth changes and document the task updates
- relax admin user payload typing and expose checkout payment results to unblock the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee2f44ceb483219596884b45a7024f