### PR TITLE
Fix reactive auth navigation

### DIFF
--- a/Tasks/TASK_20_auth-reactivity-fix.MD
+++ b/Tasks/TASK_20_auth-reactivity-fix.MD
@@ -1,0 +1,18 @@
+# TASK_20_auth-reactivity-fix
+
+## Что было сделано
+- Переподключена реактивность авторизации в Pinia и компонентах, добавлен автоматический перезапрос профиля и перенаправления после входа/выхода.
+- Обновлены навигационные компоненты и роутер, чтобы состояния и маршруты обновлялись без перезагрузки, добавлены диагностические логи.
+
+## Изменения
+- frontend/src/store/authStore.ts
+- frontend/src/components/AppNavbar.vue
+- frontend/src/router/index.ts
+- frontend/src/pages/AuthPage.vue
+- frontend/src/store/cartStore.ts
+
+## Проверка
+1. Установить зависимости: `cd frontend && npm install`.
+2. Запустить бэкенд: `cd ../backend && npm run start:dev`.
+3. В другом окне запустить фронтенд: `cd ../frontend && npm run dev -- --host` и открыть http://localhost:5173.
+4. Войти/выйти из аккаунта и перейти по основным маршрутам — в консоли должны появляться логи `Auth state changed:` и `Navigated to:` без необходимости обновлять страницу.

--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -46,8 +46,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { storeToRefs } from 'pinia';
+import { computed, ref, watchEffect } from 'vue';
 import { RouterLink, useRouter } from 'vue-router';
 import { useAuthStore } from '../store/authStore';
 import LogoutConfirmModal from './LogoutConfirmModal.vue';
@@ -55,7 +54,8 @@ import ThemeToggle from './ThemeToggle.vue';
 
 const authStore = useAuthStore();
 const router = useRouter();
-const { user, isAuthenticated } = storeToRefs(authStore);
+const user = computed(() => authStore.user);
+const isAuthenticated = computed(() => authStore.isAuthenticated);
 
 const showModal = ref(false);
 
@@ -72,4 +72,11 @@ const handleLogout = async () => {
   closeModal();
   await router.replace({ name: 'login', query: { message: 'Вы успешно вышли из аккаунта' } });
 };
+
+watchEffect(() => {
+  console.info('Navbar reactive snapshot', {
+    isAuthenticated: isAuthenticated.value,
+    user: user.value,
+  });
+});
 </script>

--- a/frontend/src/pages/AuthPage.vue
+++ b/frontend/src/pages/AuthPage.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
+import { computed, reactive, ref, watchEffect } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useAuthStore } from '../store/authStore';
 import { useRoute, useRouter } from 'vue-router';
@@ -116,6 +116,16 @@ const handleSubmit = async () => {
     success.value = '';
   }
 };
+
+watchEffect(() => {
+  if (!authStore.isAuthenticated) {
+    return;
+  }
+  const target = resolveRedirect();
+  if (router.currentRoute.value.fullPath !== target) {
+    void router.replace(target);
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -67,7 +67,7 @@ export const router = createRouter({
 });
 
 router.beforeEach(async (to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) => {
-  console.info('Navigating to', to.name ?? to.fullPath);
+  console.log('Navigating to:', to.fullPath);
   const requiresAuth = to.matched.some((route) => route.meta?.requiresAuth);
   if (!requiresAuth) {
     return next();
@@ -104,5 +104,5 @@ router.beforeEach(async (to: RouteLocationNormalized, _from: RouteLocationNormal
 });
 
 router.afterEach((to) => {
-  console.info('Navigation finished', to.name ?? to.fullPath);
+  console.log('Navigated to:', to.fullPath);
 });

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -41,8 +41,8 @@ export const useAuthStore = defineStore('auth', () => {
   };
 
   const setAuthState = (auth: AuthResponse) => {
-    persistTokens(auth);
     user.value = auth.user;
+    persistTokens(auth);
     error.value = null;
     console.info('User logged in', { id: auth.user.id, email: auth.user.email });
     logAuthState();
@@ -179,6 +179,22 @@ export const useAuthStore = defineStore('auth', () => {
       }
     },
     { flush: 'post' }
+  );
+
+  watch(
+    isAuthenticated,
+    (loggedIn) => {
+      console.log('Auth state changed:', loggedIn);
+      if (loggedIn && !user.value && !loading.value) {
+        void loadProfile();
+        return;
+      }
+
+      if (!loggedIn && user.value) {
+        user.value = null;
+      }
+    },
+    { immediate: true }
   );
 
   return {

--- a/frontend/src/store/cartStore.ts
+++ b/frontend/src/store/cartStore.ts
@@ -1,4 +1,4 @@
-import { defineStore, storeToRefs } from 'pinia';
+import { defineStore } from 'pinia';
 import { computed, ref, watch } from 'vue';
 import {
   addCartItem,
@@ -20,7 +20,7 @@ export const CART_AUTH_MESSAGE = 'Авторизуйтесь, чтобы доб�
 // store managing cart state via backend api
 export const useCartStore = defineStore('cart', () => {
   const authStore = useAuthStore();
-  const { isAuthenticated } = storeToRefs(authStore);
+  const isAuthenticated = computed(() => authStore.isAuthenticated);
 
   const cartId = ref<number | null>(null);
   const items = ref<CartItemDto[]>([]);


### PR DESCRIPTION
## Summary
- refresh the Pinia auth store to log authentication toggles and refetch a profile when tokens change
- swap navbar and auth page bindings to computed/watchEffect so links and redirects react immediately without a manual reload
- adjust router logging strings and document the task outcome

## Testing
- `npm install`
- `npm run start:dev` *(fails: backend is missing the @nestjs/swagger dependency in this environment)*
- `npm run dev -- --host 0.0.0.0 --port 4173`


------
https://chatgpt.com/codex/tasks/task_e_68ee34c086048321a2bbd68e101d3bfa