### PR TITLE
Improve checkout validation and profile auto loading

### DIFF
--- a/Tasks/TASK_24_checkout-routing.MD
+++ b/Tasks/TASK_24_checkout-routing.MD
@@ -1,0 +1,14 @@
+# TASK_24_checkout-routing
+
+## Что было сделано
+- Переработано оформление оплаты: модальные окна вынесены в Teleport, добавлены плавные анимации, строгая проверка страны и адреса, переходы выполняются через Vue Router.
+- Страница профиля теперь автоматически загружает данные пользователя при открытии, форма очищается при выходе, убрана ручная кнопка обновления.
+
+## Изменения
+- `frontend/src/pages/CheckoutPaymentPage.vue`
+- `frontend/src/pages/ProfilePage.vue`
+
+## Проверка
+- Установка зависимостей: `cd backend && npm install`, `cd ../frontend && npm install`.
+- Запуск backend: `cd backend && npm run start:dev` (процесс завис без ответа в текущем окружении, остановлен вручную).
+- Запуск frontend: `cd frontend && npm run dev -- --host` (сервер успешно стартует на `http://localhost:5173`).

--- a/frontend/src/pages/CheckoutPaymentPage.vue
+++ b/frontend/src/pages/CheckoutPaymentPage.vue
@@ -65,101 +65,125 @@
     </div>
   </section>
 
-  <div v-if="showCountryModal" class="modal fade show d-block glass-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2 class="modal-title h5">Заказ недоступен</h2>
-          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeCountryModal"></button>
-        </div>
-        <div class="modal-body">
-          <p class="mb-0">{{ countryModalMessage || 'Оформление заказов доступно только пользователям из России.' }}</p>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" @click="closeCountryModal">Понятно</button>
-          <RouterLink class="btn btn-danger" to="/profile" @click="closeCountryModal">
-            Перейти в профиль
-          </RouterLink>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div v-if="showCountryModal" class="modal-backdrop fade show"></div>
-
-  <div v-if="showAddressModal" class="modal fade show d-block glass-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg" role="document">
-      <div class="modal-content">
-        <form @submit.prevent="submitAddress">
-          <div class="modal-header">
-            <h2 class="modal-title h5">Укажите адрес доставки</h2>
-            <button type="button" class="btn-close" aria-label="Закрыть" @click="closeAddressModal" :disabled="addressSaving"></button>
-          </div>
-          <div class="modal-body">
-            <p class="text-muted">Для оформления заказа заполните все поля.</p>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="checkoutCountry" class="form-label">Страна</label>
-                <select id="checkoutCountry" v-model="addressForm.country" class="form-select" required>
-                  <option value="">Выберите страну</option>
-                  <option v-for="country in countries" :key="country" :value="country">{{ country }}</option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Город</label>
-                <div class="d-flex gap-2 flex-wrap">
-                  <select
-                    v-if="!addressForm.useCustomCity"
-                    v-model="addressForm.city"
-                    class="form-select flex-grow-1"
-                    :disabled="!addressForm.country"
-                    required
-                  >
-                    <option value="">Выберите город</option>
-                    <option v-for="cityOption in addressCityOptions" :key="cityOption" :value="cityOption">
-                      {{ cityOption }}
-                    </option>
-                  </select>
-                  <input
-                    v-else
-                    v-model="addressForm.customCity"
-                    type="text"
-                    class="form-control flex-grow-1"
-                    placeholder="Введите город"
-                    required
-                  />
-                  <button type="button" class="btn btn-outline-secondary" @click="toggleAddressCityInput">
-                    {{ addressForm.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
-                  </button>
-                </div>
-                <small class="text-muted">Выберите город или введите свой</small>
-              </div>
-              <div class="col-12">
-                <label for="checkoutAddress" class="form-label">Адрес</label>
-                <textarea
-                  id="checkoutAddress"
-                  v-model="addressForm.address"
-                  class="form-control"
-                  rows="3"
-                  placeholder="Улица, дом, квартира"
-                  required
-                ></textarea>
-              </div>
+  <Teleport to="body">
+    <Transition name="modal-fade" appear>
+      <div v-if="showCountryModal" class="modal-layer" role="presentation" @click.self="closeCountryModal">
+        <div class="modal glass-modal modal-layer__dialog" role="dialog" aria-modal="true">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h2 class="modal-title h5 mb-0">Заказ недоступен</h2>
+              <button type="button" class="btn-close" aria-label="Закрыть" @click="closeCountryModal"></button>
             </div>
-            <p v-if="addressError" class="alert alert-danger mt-3 mb-0">{{ addressError }}</p>
+            <div class="modal-body">
+              <p class="mb-0">
+                {{ countryModalMessage || 'Оформление заказов доступно только пользователям из России.' }}
+              </p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline-secondary" @click="closeCountryModal">Понятно</button>
+              <button type="button" class="btn btn-danger" @click="handleCountryModalRedirect">
+                Перейти в профиль
+              </button>
+            </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-outline-secondary" @click="closeAddressModal" :disabled="addressSaving">
-              Отмена
-            </button>
-            <button type="submit" class="btn btn-danger" :disabled="addressSaving">
-              {{ addressSaving ? 'Сохранение...' : 'Сохранить адрес' }}
-            </button>
-          </div>
-        </form>
+        </div>
       </div>
-    </div>
-  </div>
-  <div v-if="showAddressModal" class="modal-backdrop fade show"></div>
+    </Transition>
+  </Teleport>
+
+  <Teleport to="body">
+    <Transition name="modal-fade" appear>
+      <div
+        v-if="showAddressModal"
+        class="modal-layer"
+        role="presentation"
+        @click.self="closeAddressModal"
+      >
+        <div class="modal glass-modal modal-layer__dialog" role="dialog" aria-modal="true">
+          <div class="modal-content">
+            <form @submit.prevent="submitAddress">
+              <div class="modal-header">
+                <h2 class="modal-title h5 mb-0">Укажите адрес доставки</h2>
+                <button
+                  type="button"
+                  class="btn-close"
+                  aria-label="Закрыть"
+                  @click="closeAddressModal"
+                  :disabled="addressSaving"
+                ></button>
+              </div>
+              <div class="modal-body">
+                <p class="text-muted">Для оформления заказа заполните все поля.</p>
+                <div class="row g-3">
+                  <div class="col-md-6">
+                    <label for="checkoutCountry" class="form-label">Страна</label>
+                    <select id="checkoutCountry" v-model="addressForm.country" class="form-select" required>
+                      <option value="">Выберите страну</option>
+                      <option v-for="country in countries" :key="country" :value="country">{{ country }}</option>
+                    </select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Город</label>
+                    <div class="d-flex gap-2 flex-wrap">
+                      <select
+                        v-if="!addressForm.useCustomCity"
+                        v-model="addressForm.city"
+                        class="form-select flex-grow-1"
+                        :disabled="!addressForm.country"
+                        required
+                      >
+                        <option value="">Выберите город</option>
+                        <option v-for="cityOption in addressCityOptions" :key="cityOption" :value="cityOption">
+                          {{ cityOption }}
+                        </option>
+                      </select>
+                      <input
+                        v-else
+                        v-model="addressForm.customCity"
+                        type="text"
+                        class="form-control flex-grow-1"
+                        placeholder="Введите город"
+                        required
+                      />
+                      <button type="button" class="btn btn-outline-secondary" @click="toggleAddressCityInput">
+                        {{ addressForm.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
+                      </button>
+                    </div>
+                    <small class="text-muted">Выберите город или введите свой</small>
+                  </div>
+                  <div class="col-12">
+                    <label for="checkoutAddress" class="form-label">Адрес</label>
+                    <textarea
+                      id="checkoutAddress"
+                      v-model="addressForm.address"
+                      class="form-control"
+                      rows="3"
+                      placeholder="Улица, дом, квартира"
+                      required
+                    ></textarea>
+                  </div>
+                </div>
+                <p v-if="addressError" class="alert alert-danger mt-3 mb-0">{{ addressError }}</p>
+              </div>
+              <div class="modal-footer">
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  @click="closeAddressModal"
+                  :disabled="addressSaving"
+                >
+                  Отмена
+                </button>
+                <button type="submit" class="btn btn-danger" :disabled="addressSaving">
+                  {{ addressSaving ? 'Сохранение...' : 'Сохранить адрес' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -171,6 +195,7 @@ import { useCartStore } from '../store/cartStore';
 import { useAuthStore } from '../store/authStore';
 import { extractErrorMessage } from '../api/http';
 import { SUPPORTED_COUNTRIES, getCitiesByCountry, isRussianCountry } from '../utils/location';
+import { useNavigation } from '../composables/useNavigation';
 
 const cartStore = useCartStore();
 const { items, totalAmount, totalQuantity, loading, updating, error, lastOrder } = storeToRefs(cartStore);
@@ -198,12 +223,30 @@ const addressError = ref<string | null>(null);
 const showCountryModal = ref(false);
 const countryModalMessage = ref('');
 const showAddressModal = ref(false);
+const { goToProfile } = useNavigation();
 
 const addressCityOptions = computed(() => getCitiesByCountry(addressForm.country));
 
 const hasRussianCountry = computed(() => isRussianCountry(user.value?.country));
 const hasUserCity = computed(() => (user.value?.city ?? '').trim().length > 0);
 const hasUserAddress = computed(() => (user.value?.address ?? '').trim().length > 0);
+
+const resolveMissingAddressMessage = () => {
+  const missing: string[] = [];
+  if (!hasUserCity.value) {
+    missing.push('город');
+  }
+  if (!hasUserAddress.value) {
+    missing.push('адрес');
+  }
+  if (missing.length === 0) {
+    return '';
+  }
+  if (missing.length === 1) {
+    return `Укажите ${missing[0]} доставки.`;
+  }
+  return 'Укажите город и полный адрес доставки.';
+};
 
 const resolveCountryErrorMessage = () => {
   const selectedCountry = (user.value?.country ?? '').trim();
@@ -254,7 +297,7 @@ const payOrder = async () => {
   }
   if (!hasUserCity.value || !hasUserAddress.value) {
     fillAddressFormFromProfile();
-    addressError.value = 'Укажите город и полный адрес доставки.';
+    addressError.value = resolveMissingAddressMessage();
     showAddressModal.value = true;
     return;
   }
@@ -269,6 +312,15 @@ const payOrder = async () => {
 const closeCountryModal = () => {
   showCountryModal.value = false;
   countryModalMessage.value = '';
+};
+
+const handleCountryModalRedirect = async () => {
+  if (addressSaving.value) {
+    return;
+  }
+  showCountryModal.value = false;
+  countryModalMessage.value = '';
+  await goToProfile();
 };
 
 const closeAddressModal = () => {
@@ -357,12 +409,75 @@ watch(showAddressModal, (visible) => {
   }
 });
 
+watch(
+  () => addressForm.country,
+  (country) => {
+    const options = getCitiesByCountry(country);
+    if (!addressForm.useCustomCity && addressForm.city && !options.includes(addressForm.city)) {
+      addressForm.city = '';
+    }
+  },
+);
+
+watch(
+  () => [addressForm.city, addressForm.customCity, addressForm.address, addressForm.country, addressForm.useCustomCity],
+  () => {
+    if (addressError.value) {
+      addressError.value = null;
+    }
+  },
+);
+
 onMounted(() => {
   void cartStore.loadCart();
+  if (!user.value) {
+    void authStore.loadProfile().catch((err) => {
+      console.error('Failed to refresh profile before checkout', err);
+    });
+  }
 });
 </script>
 
 <style scoped>
+.modal-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 3vw, 2rem);
+  background: color-mix(in srgb, rgba(5, 5, 10, 0.65) 72%, transparent);
+  backdrop-filter: blur(4px);
+}
+
+.modal-layer__dialog {
+  width: min(640px, 100%);
+  max-height: min(90vh, 720px);
+  overflow: hidden;
+  box-shadow: var(--shadow-modal, 0 24px 60px rgba(0, 0, 0, 0.45));
+  animation: modal-pop var(--transition-base) ease;
+}
+
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.24s ease, transform 0.24s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+}
+
+@keyframes modal-pop {
+  from {
+    transform: translateY(18px) scale(0.95);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
+}
+
 .page-header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -6,9 +6,6 @@
           <span class="chip mb-2">Профиль</span>
           <h1 class="section-title mb-0">Личные данные</h1>
         </div>
-        <button class="btn btn-outline-secondary" type="button" @click="refreshProfile" :disabled="loading">
-          Обновить данные
-        </button>
       </div>
 
       <div v-if="!isAuthenticated" class="alert alert-warning" role="alert">
@@ -198,12 +195,6 @@ const cityOptions = computed(() => getCitiesByCountry(form.country));
 
 const canSubmit = computed(() => form.name.trim().length >= 2 && form.email.trim().length > 0);
 
-const refreshProfile = () => {
-  localError.value = null;
-  successMessage.value = '';
-  void authStore.loadProfile();
-};
-
 const toggleCityInput = () => {
   form.useCustomCity = !form.useCustomCity;
   form.city = '';
@@ -233,6 +224,14 @@ const saveProfile = async () => {
 
 watch(user, (value) => {
   if (!value) {
+    form.name = '';
+    form.email = '';
+    form.phone = '';
+    form.country = '';
+    form.city = '';
+    form.customCity = '';
+    form.useCustomCity = false;
+    form.address = '';
     return;
   }
   form.name = value.name ?? '';
@@ -256,9 +255,19 @@ watch(error, (value) => {
 });
 
 onMounted(() => {
-  if (!user.value) {
-    void authStore.loadProfile();
+  if (!isAuthenticated.value) {
+    return;
   }
+  localError.value = null;
+  successMessage.value = '';
+  void authStore
+    .loadProfile()
+    .catch((err) => {
+      console.error('Failed to load profile data', err);
+      if (!localError.value) {
+        localError.value = 'Не удалось загрузить профиль. Попробуйте позже.';
+      }
+    });
 });
 </script>
 


### PR DESCRIPTION
## Summary
- move checkout validation dialogs into Teleport overlays with transitions and enforce Russia-only shipping before payment
- ensure address completion requires city and street details, updating profile navigation to go through the router
- preload profile information automatically on entry and document the work in the task log

## Testing
- npm run start:dev *(hangs without database connection, terminated manually)*
- npm run dev -- --host

------
https://chatgpt.com/codex/tasks/task_e_68ee490c3fa4832186c4e3b5f14de1b6