### PR TITLE
feat: align backend with size stock and reviews

### DIFF
--- a/Tasks/TASK_1_database-rework.MD
+++ b/Tasks/TASK_1_database-rework.MD
@@ -1,0 +1,22 @@
+# TASK 1 — Database Rework
+
+## Что сделано
+- Переписан `backend/database/schema.sql` под новую модель данных с таблицами `product_sizes`, `size_stock`, `reviews`, обновлёнными связями и триггерами аудита.
+- Добавлены обновлённые `VIEW` для аналитики, включая `vw_sales_by_day`.
+- Пересобраны сиды товаров, размеров, остатков и отзывов.
+
+## Пути изменений
+- `backend/database/schema.sql`
+
+## Команды для проверки
+```bash
+sudo -u postgres dropdb slipknot_shop
+sudo -u postgres createdb slipknot_shop
+sudo -u postgres psql -d slipknot_shop -f backend/database/schema.sql
+sudo -u postgres psql -d slipknot_shop -c "SELECT p.sku, ps.size, ss.stock FROM products p JOIN product_sizes ps ON ps.product_id = p.id JOIN size_stock ss ON ss.size_id = ps.id ORDER BY p.sku, ps.size;"
+sudo -u postgres psql -d slipknot_shop -c "SELECT u.email, p.sku, r.rating, r.status FROM reviews r JOIN users u ON u.id=r.user_id JOIN products p ON p.id=r.product_id;"
+```
+
+## Результаты
+- Скрипт инициализации выполняется без ошибок; выводы проверочных запросов подтверждают корректную загрузку размеров, остатков и отзывов.
+- Скриншоты не приложены из-за ограничений терминального окружения.

--- a/Tasks/TASK_2_backend-update.MD
+++ b/Tasks/TASK_2_backend-update.MD
@@ -1,0 +1,27 @@
+# TASK 2 — Backend Update
+
+## Что сделано
+- Добавлена полноценная поддержка размерных остатков: новые сущности `ProductSize` и `SizeStock`, переработанные DTO и сервисы товаров, эндпоинт `GET /products/:id/sizes`.
+- Обновлены корзина и заказы для работы с размерами: DTO, сервис корзины, сущности позиций заказа/корзины и ответов, учёт выбранного размера при оформлении.
+- Реализован модуль отзывов (`POST /reviews`, `GET /reviews/:productId`) с сущностью, DTO и сервисом модерации по умолчанию.
+- Расширены сущности пользователей и товаров связями с отзывами, обновлён `app.module.ts`, аудит-сабскрайбер и guard корзины.
+
+## Задействованные файлы
+- `backend/src/modules/products/**/*`
+- `backend/src/modules/carts/**/*`
+- `backend/src/modules/orders/**/*`
+- `backend/src/modules/cart-items/entities/cart-item.entity.ts`
+- `backend/src/modules/order-items/entities/order-item.entity.ts`
+- `backend/src/modules/users/entities/user.entity.ts`
+- `backend/src/modules/reviews/**/*`
+- `backend/src/common/audit/audit.subscriber.ts`
+- `backend/src/app.module.ts`
+
+## Команды для проверки
+```bash
+cd backend
+npx eslint src/modules/products src/modules/carts src/modules/orders src/modules/reviews src/modules/cart-items/entities/cart-item.entity.ts src/modules/order-items/entities/order-item.entity.ts src/modules/users/entities/user.entity.ts src/common/audit/audit.subscriber.ts src/app.module.ts
+```
+
+## Результаты тестов
+- `npx eslint …` — без ошибок (проверены обновлённые модули).

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { OrdersModule } from './modules/orders/orders.module';
 import { OrderStatusesModule } from './modules/order-statuses/order-statuses.module';
 import { CartsModule } from './modules/carts/carts.module';
 import { AuditLogModule } from './modules/audit-log/audit-log.module';
+import { ReviewsModule } from './modules/reviews/reviews.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { buildTypeOrmOptions } from './config/typeorm.config';
@@ -35,6 +36,7 @@ import { RequestLoggingInterceptor } from './common/interceptors/request-logging
     OrdersModule,
     OrderStatusesModule,
     CartsModule,
+    ReviewsModule,
     AuditLogModule,
   ],
   controllers: [AppController],

--- a/backend/src/common/audit/audit.subscriber.ts
+++ b/backend/src/common/audit/audit.subscriber.ts
@@ -22,7 +22,7 @@ export class AuditSubscriber implements EntitySubscriberInterface {
     this.dataSource.subscribers.push(this);
   }
 
-  listenTo(): Function {
+  listenTo(): new (...args: unknown[]) => unknown {
     return Object;
   }
 
@@ -43,7 +43,9 @@ export class AuditSubscriber implements EntitySubscriberInterface {
   ): Promise<void> {
     const userId = this.auditContextService.getCurrentUserId();
     try {
-      await event.queryRunner.query('SELECT set_current_app_user($1)', [userId ?? null]);
+      await event.queryRunner.query('SELECT set_current_app_user($1)', [
+        userId ?? null,
+      ]);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(`Failed to set current app user for audit: ${message}`);

--- a/backend/src/modules/cart-items/entities/cart-item.entity.ts
+++ b/backend/src/modules/cart-items/entities/cart-item.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { Cart } from '../../carts/entities/cart.entity';
 import { Product } from '../../products/entities/product.entity';
+import { ProductSize } from '../../products/entities/product-size.entity';
 
 // cart item entity
 @Entity({ name: 'cart_items' })
@@ -23,6 +24,12 @@ export class CartItem {
   @ManyToOne(() => Product, (product) => product.cartItems)
   @JoinColumn({ name: 'product_id' })
   product: Product;
+
+  @ManyToOne(() => ProductSize, (productSize) => productSize.cartItems, {
+    nullable: true,
+  })
+  @JoinColumn({ name: 'product_size_id' })
+  productSize?: ProductSize | null;
 
   @Column({ type: 'integer' })
   quantity: number;

--- a/backend/src/modules/carts/carts.controller.ts
+++ b/backend/src/modules/carts/carts.controller.ts
@@ -85,7 +85,10 @@ export class CartsController {
   @Post('checkout')
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Оформить заказ из корзины' })
-  @ApiOkResponse({ description: 'Информация о созданном заказе', type: CheckoutResponseDto })
+  @ApiOkResponse({
+    description: 'Информация о созданном заказе',
+    type: CheckoutResponseDto,
+  })
   @ApiUnauthorizedResponse({ description: 'Пользователь не авторизован' })
   checkout(@Req() req: AuthenticatedRequest): Promise<CheckoutResponseDto> {
     return this.cartsService.checkout(req.user.id);

--- a/backend/src/modules/carts/carts.module.ts
+++ b/backend/src/modules/carts/carts.module.ts
@@ -5,6 +5,8 @@ import { CartsController } from './carts.controller';
 import { Cart } from './entities/cart.entity';
 import { CartItem } from '../cart-items/entities/cart-item.entity';
 import { Product } from '../products/entities/product.entity';
+import { ProductSize } from '../products/entities/product-size.entity';
+import { SizeStock } from '../products/entities/size-stock.entity';
 import { User } from '../users/entities/user.entity';
 import { Order } from '../orders/entities/order.entity';
 import { OrderItem } from '../order-items/entities/order-item.entity';
@@ -14,7 +16,17 @@ import { CartAuthGuard } from './guards/cart-auth.guard';
 // module providing cart functionality
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Cart, CartItem, Product, User, Order, OrderItem, OrderStatus]),
+    TypeOrmModule.forFeature([
+      Cart,
+      CartItem,
+      Product,
+      ProductSize,
+      SizeStock,
+      User,
+      Order,
+      OrderItem,
+      OrderStatus,
+    ]),
   ],
   controllers: [CartsController],
   providers: [CartsService, CartAuthGuard],

--- a/backend/src/modules/carts/dto/add-cart-item.dto.ts
+++ b/backend/src/modules/carts/dto/add-cart-item.dto.ts
@@ -7,7 +7,20 @@ export class AddCartItemDto {
   @IsInt({ message: 'Идентификатор товара должен быть числом' })
   productId: number;
 
-  @ApiPropertyOptional({ example: 2, description: 'Количество товара', minimum: 1 })
+  @ApiPropertyOptional({
+    example: 45,
+    description: 'Идентификатор размера товара',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsInt({ message: 'Идентификатор размера должен быть числом' })
+  productSizeId?: number | null;
+
+  @ApiPropertyOptional({
+    example: 2,
+    description: 'Количество товара',
+    minimum: 1,
+  })
   @IsOptional()
   @IsInt({ message: 'Количество должно быть целым числом' })
   @Min(1, { message: 'Количество должно быть не меньше 1' })

--- a/backend/src/modules/carts/dto/cart-item-response.dto.ts
+++ b/backend/src/modules/carts/dto/cart-item-response.dto.ts
@@ -4,7 +4,10 @@ class CartItemProductDto {
   @ApiProperty({ example: 15, description: 'Идентификатор товара' })
   id: number;
 
-  @ApiProperty({ example: 'Футболка Slipknot Iowa', description: 'Название товара' })
+  @ApiProperty({
+    example: 'Футболка Slipknot Iowa',
+    description: 'Название товара',
+  })
   title: string;
 
   @ApiProperty({ example: 2990, description: 'Цена товара' })
@@ -18,6 +21,23 @@ class CartItemProductDto {
   imageUrl: string | null;
 }
 
+class CartItemSizeDto {
+  @ApiProperty({
+    example: 42,
+    description: 'Идентификатор размера в таблице product_sizes',
+  })
+  id: number;
+
+  @ApiProperty({ example: 'L', description: 'Название выбранного размера' })
+  size: string;
+
+  @ApiProperty({
+    example: 8,
+    description: 'Текущее количество на складе для размера',
+  })
+  stock: number;
+}
+
 // response dto for single cart item
 export class CartItemResponseDto {
   @ApiProperty({ example: 9, description: 'Идентификатор позиции в корзине' })
@@ -29,6 +49,16 @@ export class CartItemResponseDto {
   @ApiProperty({ example: 2990, description: 'Цена за единицу товара' })
   unitPrice: number;
 
-  @ApiProperty({ type: () => CartItemProductDto, description: 'Информация о товаре' })
+  @ApiProperty({
+    type: () => CartItemProductDto,
+    description: 'Информация о товаре',
+  })
   product: CartItemProductDto;
+
+  @ApiPropertyOptional({
+    type: () => CartItemSizeDto,
+    nullable: true,
+    description: 'Информация о выбранном размере',
+  })
+  size: CartItemSizeDto | null;
 }

--- a/backend/src/modules/carts/dto/cart-response.dto.ts
+++ b/backend/src/modules/carts/dto/cart-response.dto.ts
@@ -6,10 +6,17 @@ export class CartResponseDto {
   @ApiProperty({ example: 5, description: 'Идентификатор корзины' })
   id: number;
 
-  @ApiProperty({ type: () => CartItemResponseDto, isArray: true, description: 'Позиции в корзине' })
+  @ApiProperty({
+    type: () => CartItemResponseDto,
+    isArray: true,
+    description: 'Позиции в корзине',
+  })
   items: CartItemResponseDto[];
 
-  @ApiProperty({ example: 3, description: 'Общее количество товаров в корзине' })
+  @ApiProperty({
+    example: 3,
+    description: 'Общее количество товаров в корзине',
+  })
   totalQuantity: number;
 
   @ApiProperty({ example: 5980, description: 'Сумма заказа по корзине' })

--- a/backend/src/modules/carts/dto/checkout-response.dto.ts
+++ b/backend/src/modules/carts/dto/checkout-response.dto.ts
@@ -8,7 +8,10 @@ export class CheckoutResponseDto {
   @ApiProperty({ example: 5980, description: 'Итоговая сумма заказа' })
   totalAmount: number;
 
-  @ApiProperty({ example: 'Готовится к отправке', description: 'Статус отправки заказа' })
+  @ApiProperty({
+    example: 'Готовится к отправке',
+    description: 'Статус отправки заказа',
+  })
   shippingStatus: string;
 
   @ApiProperty({ description: 'Дата последнего обновления статуса отправки' })

--- a/backend/src/modules/carts/dto/update-cart-item.dto.ts
+++ b/backend/src/modules/carts/dto/update-cart-item.dto.ts
@@ -3,7 +3,11 @@ import { IsInt, Min } from 'class-validator';
 
 // dto for updating cart item quantity
 export class UpdateCartItemDto {
-  @ApiProperty({ example: 3, description: 'Новое количество товара', minimum: 1 })
+  @ApiProperty({
+    example: 3,
+    description: 'Новое количество товара',
+    minimum: 1,
+  })
   @IsInt({ message: 'Количество должно быть целым числом' })
   @Min(1, { message: 'Количество должно быть не меньше 1' })
   quantity: number;

--- a/backend/src/modules/carts/guards/cart-auth.guard.ts
+++ b/backend/src/modules/carts/guards/cart-auth.guard.ts
@@ -1,12 +1,14 @@
 import { AuthGuard } from '@nestjs/passport';
-import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 
 // guard for cart routes with custom unauthorized message
 @Injectable()
 export class CartAuthGuard extends AuthGuard('jwt') {
-  handleRequest(err: unknown, user: any, _info?: unknown, _context?: ExecutionContext) {
+  handleRequest(err: unknown, user: any) {
     if (err || !user) {
-      throw new UnauthorizedException('Авторизуйтесь, чтобы добавить товар в корзину');
+      throw new UnauthorizedException(
+        'Авторизуйтесь, чтобы добавить товар в корзину',
+      );
     }
     return user;
   }

--- a/backend/src/modules/order-items/entities/order-item.entity.ts
+++ b/backend/src/modules/order-items/entities/order-item.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { Order } from '../../orders/entities/order.entity';
 import { Product } from '../../products/entities/product.entity';
+import { ProductSize } from '../../products/entities/product-size.entity';
 
 // order item entity
 @Entity({ name: 'order_items' })
@@ -23,6 +24,12 @@ export class OrderItem {
   @ManyToOne(() => Product, (product) => product.orderItems)
   @JoinColumn({ name: 'product_id' })
   product: Product;
+
+  @ManyToOne(() => ProductSize, (productSize) => productSize.orderItems, {
+    nullable: true,
+  })
+  @JoinColumn({ name: 'product_size_id' })
+  productSize?: ProductSize | null;
 
   @Column({ type: 'integer' })
   quantity: number;

--- a/backend/src/modules/orders/customer-orders.controller.ts
+++ b/backend/src/modules/orders/customer-orders.controller.ts
@@ -1,5 +1,10 @@
 import { Controller, Get, Req, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Request } from 'express';
 import { OrdersService } from './orders.service';
 import { CustomerOrderResponseDto } from './dto/customer-order-response.dto';
@@ -19,8 +24,14 @@ export class CustomerOrdersController {
 
   @Get()
   @ApiOperation({ summary: 'Получить историю заказов текущего пользователя' })
-  @ApiOkResponse({ description: 'История заказов', type: CustomerOrderResponseDto, isArray: true })
-  findMyOrders(@Req() req: AuthenticatedRequest): Promise<CustomerOrderResponseDto[]> {
+  @ApiOkResponse({
+    description: 'История заказов',
+    type: CustomerOrderResponseDto,
+    isArray: true,
+  })
+  findMyOrders(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CustomerOrderResponseDto[]> {
     return this.ordersService.findForUser(req.user.id);
   }
 }

--- a/backend/src/modules/orders/dto/create-order.dto.ts
+++ b/backend/src/modules/orders/dto/create-order.dto.ts
@@ -1,13 +1,23 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt, IsNumber, IsOptional, IsPositive, IsString, MaxLength, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
 
 // dto for creating a new order from manager panel
 export class CreateOrderDto {
   @ApiProperty({ example: 1, description: 'Идентификатор пользователя' })
   @Type(() => Number)
   @IsInt({ message: 'Пользователь должен быть указан' })
-  @IsPositive({ message: 'Идентификатор пользователя должен быть положительным' })
+  @IsPositive({
+    message: 'Идентификатор пользователя должен быть положительным',
+  })
   userId: number;
 
   @ApiProperty({ example: 2, description: 'Идентификатор статуса заказа' })
@@ -18,28 +28,47 @@ export class CreateOrderDto {
 
   @ApiProperty({ example: 7490.5, description: 'Итоговая сумма заказа' })
   @Type(() => Number)
-  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Сумма заказа должна быть числом' })
+  @IsNumber(
+    { maxDecimalPlaces: 2 },
+    { message: 'Сумма заказа должна быть числом' },
+  )
   @Min(0, { message: 'Сумма заказа не может быть отрицательной' })
   totalAmount: number;
 
-  @ApiPropertyOptional({ example: 'Банковская карта', description: 'Способ оплаты' })
+  @ApiPropertyOptional({
+    example: 'Банковская карта',
+    description: 'Способ оплаты',
+  })
   @IsOptional()
   @IsString({ message: 'Способ оплаты должен быть строкой' })
-  @MaxLength(100, { message: 'Способ оплаты должен содержать не более 100 символов' })
+  @MaxLength(100, {
+    message: 'Способ оплаты должен содержать не более 100 символов',
+  })
   paymentMethod?: string;
 
-  @ApiPropertyOptional({ example: 'Готовится к отправке', description: 'Статус доставки' })
+  @ApiPropertyOptional({
+    example: 'Готовится к отправке',
+    description: 'Статус доставки',
+  })
   @IsOptional()
   @IsString({ message: 'Статус доставки должен быть строкой' })
-  @MaxLength(120, { message: 'Статус доставки должен содержать не более 120 символов' })
+  @MaxLength(120, {
+    message: 'Статус доставки должен содержать не более 120 символов',
+  })
   shippingStatus?: string;
 
-  @ApiPropertyOptional({ example: 'Позвонить перед доставкой', description: 'Комментарий менеджера' })
+  @ApiPropertyOptional({
+    example: 'Позвонить перед доставкой',
+    description: 'Комментарий менеджера',
+  })
   @IsOptional()
   @IsString({ message: 'Комментарий должен быть строкой' })
   comment?: string;
 
-  @ApiPropertyOptional({ example: 5, description: 'Идентификатор адреса доставки' })
+  @ApiPropertyOptional({
+    example: 5,
+    description: 'Идентификатор адреса доставки',
+  })
   @Type(() => Number)
   @IsOptional()
   @IsInt({ message: 'Идентификатор адреса должен быть целым числом' })

--- a/backend/src/modules/orders/dto/customer-order-response.dto.ts
+++ b/backend/src/modules/orders/dto/customer-order-response.dto.ts
@@ -4,7 +4,10 @@ class CustomerOrderStatusDto {
   @ApiProperty({ example: 2, description: 'Идентификатор статуса заказа' })
   id: number;
 
-  @ApiProperty({ example: 'В обработке', description: 'Название статуса заказа' })
+  @ApiProperty({
+    example: 'В обработке',
+    description: 'Название статуса заказа',
+  })
   name: string;
 }
 
@@ -16,13 +19,23 @@ export class CustomerOrderResponseDto {
   @ApiProperty({ example: 5980, description: 'Итоговая сумма заказа' })
   totalAmount: number;
 
-  @ApiProperty({ type: () => CustomerOrderStatusDto, description: 'Статус оплаты/заказа' })
+  @ApiProperty({
+    type: () => CustomerOrderStatusDto,
+    description: 'Статус оплаты/заказа',
+  })
   status: CustomerOrderStatusDto;
 
-  @ApiPropertyOptional({ example: 'Оплата картой онлайн', description: 'Способ оплаты', nullable: true })
+  @ApiPropertyOptional({
+    example: 'Оплата картой онлайн',
+    description: 'Способ оплаты',
+    nullable: true,
+  })
   paymentMethod: string | null;
 
-  @ApiProperty({ example: 'Готовится к отправке', description: 'Текущий статус отправки заказа' })
+  @ApiProperty({
+    example: 'Готовится к отправке',
+    description: 'Текущий статус отправки заказа',
+  })
   shippingStatus: string;
 
   @ApiProperty({ description: 'Дата последнего обновления статуса отправки' })

--- a/backend/src/modules/orders/dto/order-customer.dto.ts
+++ b/backend/src/modules/orders/dto/order-customer.dto.ts
@@ -8,6 +8,9 @@ export class OrderCustomerDto {
   @ApiProperty({ example: 'Сид Уилсон', description: 'Имя покупателя' })
   name: string;
 
-  @ApiProperty({ example: 'sid@slipknot.com', description: 'Электронная почта покупателя' })
+  @ApiProperty({
+    example: 'sid@slipknot.com',
+    description: 'Электронная почта покупателя',
+  })
   email: string;
 }

--- a/backend/src/modules/orders/dto/order-item-response.dto.ts
+++ b/backend/src/modules/orders/dto/order-item-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 class OrderItemProductDto {
   @ApiProperty({ example: 7, description: 'Идентификатор товара' })
@@ -11,13 +11,31 @@ class OrderItemProductDto {
   sku: string;
 }
 
+class OrderItemSizeDto {
+  @ApiProperty({ example: 12, description: 'Идентификатор размера товара' })
+  id: number;
+
+  @ApiProperty({ example: 'L', description: 'Размер заказа' })
+  size: string;
+}
+
 // dto describing order item for manager view
 export class OrderItemResponseDto {
   @ApiProperty({ example: 12, description: 'Идентификатор позиции заказа' })
   id: number;
 
-  @ApiProperty({ type: () => OrderItemProductDto, description: 'Краткая информация о товаре' })
+  @ApiProperty({
+    type: () => OrderItemProductDto,
+    description: 'Краткая информация о товаре',
+  })
   product: OrderItemProductDto;
+
+  @ApiPropertyOptional({
+    type: () => OrderItemSizeDto,
+    nullable: true,
+    description: 'Информация о выбранном размере',
+  })
+  size: OrderItemSizeDto | null;
 
   @ApiProperty({ example: 2, description: 'Количество товара в заказе' })
   quantity: number;

--- a/backend/src/modules/orders/dto/order-response.dto.ts
+++ b/backend/src/modules/orders/dto/order-response.dto.ts
@@ -8,7 +8,10 @@ class OrderCustomerDto {
   @ApiProperty({ example: 'Джоуи Джордисон', description: 'Имя покупателя' })
   name: string;
 
-  @ApiProperty({ example: 'joey@slipknot.com', description: 'Email покупателя' })
+  @ApiProperty({
+    example: 'joey@slipknot.com',
+    description: 'Email покупателя',
+  })
   email: string;
 }
 
@@ -16,7 +19,10 @@ class OrderStatusDto {
   @ApiProperty({ example: 2, description: 'Идентификатор статуса заказа' })
   id: number;
 
-  @ApiProperty({ example: 'В обработке', description: 'Название статуса заказа' })
+  @ApiProperty({
+    example: 'В обработке',
+    description: 'Название статуса заказа',
+  })
   name: string;
 }
 
@@ -33,7 +39,11 @@ class OrderAddressDto {
   @ApiProperty({ example: '119002', description: 'Почтовый индекс' })
   postalCode: string;
 
-  @ApiPropertyOptional({ example: 'Домофон 12', description: 'Комментарий к адресу', nullable: true })
+  @ApiPropertyOptional({
+    example: 'Домофон 12',
+    description: 'Комментарий к адресу',
+    nullable: true,
+  })
   comment: string | null;
 }
 
@@ -42,31 +52,56 @@ export class OrderResponseDto {
   @ApiProperty({ example: 101, description: 'Идентификатор заказа' })
   id: number;
 
-  @ApiProperty({ type: () => OrderCustomerDto, description: 'Информация о покупателе' })
+  @ApiProperty({
+    type: () => OrderCustomerDto,
+    description: 'Информация о покупателе',
+  })
   customer: OrderCustomerDto;
 
-  @ApiProperty({ type: () => OrderStatusDto, description: 'Текущий статус заказа' })
+  @ApiProperty({
+    type: () => OrderStatusDto,
+    description: 'Текущий статус заказа',
+  })
   status: OrderStatusDto;
 
   @ApiProperty({ example: 5980, description: 'Итоговая сумма заказа' })
   totalAmount: number;
 
-  @ApiPropertyOptional({ example: 'Картой при получении', description: 'Способ оплаты', nullable: true })
+  @ApiPropertyOptional({
+    example: 'Картой при получении',
+    description: 'Способ оплаты',
+    nullable: true,
+  })
   paymentMethod: string | null;
 
-  @ApiPropertyOptional({ example: 'Позвонить за час до доставки', description: 'Комментарий менеджера', nullable: true })
+  @ApiPropertyOptional({
+    example: 'Позвонить за час до доставки',
+    description: 'Комментарий менеджера',
+    nullable: true,
+  })
   comment: string | null;
 
-  @ApiProperty({ type: () => OrderAddressDto, nullable: true, description: 'Адрес доставки' })
+  @ApiProperty({
+    type: () => OrderAddressDto,
+    nullable: true,
+    description: 'Адрес доставки',
+  })
   address: OrderAddressDto | null;
 
-  @ApiProperty({ type: () => OrderItemResponseDto, isArray: true, description: 'Состав заказа' })
+  @ApiProperty({
+    type: () => OrderItemResponseDto,
+    isArray: true,
+    description: 'Состав заказа',
+  })
   items: OrderItemResponseDto[];
 
   @ApiProperty({ description: 'Дата оформления заказа' })
   placedAt: Date;
 
-  @ApiProperty({ example: 'Готовится к отправке', description: 'Текущий статус отправки заказа' })
+  @ApiProperty({
+    example: 'Готовится к отправке',
+    description: 'Текущий статус отправки заказа',
+  })
   shippingStatus: string;
 
   @ApiProperty({ description: 'Дата последнего обновления статуса отправки' })

--- a/backend/src/modules/orders/dto/update-order.dto.ts
+++ b/backend/src/modules/orders/dto/update-order.dto.ts
@@ -18,20 +18,33 @@ export class UpdateOrderDto {
 
   @ApiPropertyOptional({ example: 7490, description: 'Новая сумма заказа' })
   @IsOptional()
-  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Сумма заказа должна быть числом' })
+  @IsNumber(
+    { maxDecimalPlaces: 2 },
+    { message: 'Сумма заказа должна быть числом' },
+  )
   @IsPositive({ message: 'Сумма заказа должна быть больше нуля' })
   totalAmount?: number;
 
-  @ApiPropertyOptional({ example: 'Оплата картой онлайн', description: 'Способ оплаты' })
+  @ApiPropertyOptional({
+    example: 'Оплата картой онлайн',
+    description: 'Способ оплаты',
+  })
   @IsOptional()
   @IsString({ message: 'Способ оплаты должен быть строкой' })
-  @MaxLength(100, { message: 'Название способа оплаты должно содержать не более 100 символов' })
+  @MaxLength(100, {
+    message: 'Название способа оплаты должно содержать не более 100 символов',
+  })
   paymentMethod?: string;
 
-  @ApiPropertyOptional({ example: 'Уточнить время доставки', description: 'Комментарий менеджера' })
+  @ApiPropertyOptional({
+    example: 'Уточнить время доставки',
+    description: 'Комментарий менеджера',
+  })
   @IsOptional()
   @IsString({ message: 'Комментарий должен быть строкой' })
-  @MaxLength(1000, { message: 'Комментарий должен содержать не более 1000 символов' })
+  @MaxLength(1000, {
+    message: 'Комментарий должен содержать не более 1000 символов',
+  })
   comment?: string;
 
   @ApiPropertyOptional({
@@ -40,6 +53,8 @@ export class UpdateOrderDto {
   })
   @IsOptional()
   @IsString({ message: 'Статус отправки должен быть строкой' })
-  @MaxLength(120, { message: 'Статус отправки должен содержать не более 120 символов' })
+  @MaxLength(120, {
+    message: 'Статус отправки должен содержать не более 120 символов',
+  })
   shippingStatus?: string;
 }

--- a/backend/src/modules/orders/entities/order.entity.ts
+++ b/backend/src/modules/orders/entities/order.entity.ts
@@ -35,7 +35,12 @@ export class Order {
   @Column({ name: 'total_amount', type: 'numeric', precision: 10, scale: 2 })
   totalAmount: string;
 
-  @Column({ name: 'payment_method', type: 'varchar', length: 100, nullable: true })
+  @Column({
+    name: 'payment_method',
+    type: 'varchar',
+    length: 100,
+    nullable: true,
+  })
   paymentMethod?: string | null;
 
   @Column({
@@ -56,7 +61,11 @@ export class Order {
   @Column({ type: 'text', nullable: true })
   comment?: string | null;
 
-  @Column({ name: 'placed_at', type: 'timestamp with time zone', default: () => 'NOW()' })
+  @Column({
+    name: 'placed_at',
+    type: 'timestamp with time zone',
+    default: () => 'NOW()',
+  })
   placedAt: Date;
 
   @OneToMany(() => OrderItem, (item) => item.order)

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBadRequestResponse,
@@ -37,14 +47,22 @@ export class OrdersController {
 
   @Get()
   @ApiOperation({ summary: 'Получить список заказов' })
-  @ApiOkResponse({ description: 'Список заказов', type: OrderResponseDto, isArray: true })
+  @ApiOkResponse({
+    description: 'Список заказов',
+    type: OrderResponseDto,
+    isArray: true,
+  })
   findAll(): Promise<OrderResponseDto[]> {
     return this.ordersService.findAll();
   }
 
   @Get('customers')
   @ApiOperation({ summary: 'Получить список покупателей' })
-  @ApiOkResponse({ description: 'Покупатели для выбора при создании заказа', type: OrderCustomerDto, isArray: true })
+  @ApiOkResponse({
+    description: 'Покупатели для выбора при создании заказа',
+    type: OrderCustomerDto,
+    isArray: true,
+  })
   findCustomers(): Promise<OrderCustomerDto[]> {
     return this.ordersService.findCustomers();
   }

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -36,7 +36,9 @@ export class OrdersService {
       address = await this.findAddressById(createOrderDto.addressId);
     }
 
-    const shippingStatus = (createOrderDto.shippingStatus?.trim() || DEFAULT_SHIPPING_STATUS).slice(0, 120);
+    const shippingStatus = (
+      createOrderDto.shippingStatus?.trim() || DEFAULT_SHIPPING_STATUS
+    ).slice(0, 120);
     const paymentMethod = createOrderDto.paymentMethod?.trim() || null;
     const comment = createOrderDto.comment?.trim() || null;
 
@@ -61,7 +63,7 @@ export class OrdersService {
         user: true,
         status: true,
         address: true,
-        items: { product: true },
+        items: { product: true, productSize: true },
       },
       order: { id: 'ASC' },
     });
@@ -93,7 +95,7 @@ export class OrdersService {
         user: true,
         status: true,
         address: true,
-        items: { product: true },
+        items: { product: true, productSize: true },
       },
     });
 
@@ -104,7 +106,10 @@ export class OrdersService {
     return this.toOrderResponse(order);
   }
 
-  async update(id: number, updateOrderDto: UpdateOrderDto): Promise<OrderResponseDto> {
+  async update(
+    id: number,
+    updateOrderDto: UpdateOrderDto,
+  ): Promise<OrderResponseDto> {
     const order = await this.ordersRepository.findOne({
       where: { id },
       relations: {
@@ -138,7 +143,9 @@ export class OrdersService {
 
     if (updateOrderDto.shippingStatus !== undefined) {
       const shippingStatus = updateOrderDto.shippingStatus.trim();
-      const normalizedStatus = shippingStatus.length ? shippingStatus : DEFAULT_SHIPPING_STATUS;
+      const normalizedStatus = shippingStatus.length
+        ? shippingStatus
+        : DEFAULT_SHIPPING_STATUS;
       if (order.shippingStatus !== normalizedStatus) {
         order.shippingStatus = normalizedStatus;
         order.shippingUpdatedAt = new Date();
@@ -208,6 +215,12 @@ export class OrdersService {
         title: item.product?.title ?? 'Товар удален',
         sku: item.product?.sku ?? '—',
       },
+      size: item.productSize
+        ? {
+            id: item.productSize.id,
+            size: item.productSize.size,
+          }
+        : null,
       quantity: item.quantity,
       unitPrice: Number(item.unitPrice),
     }));

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
+  IsArray,
   IsInt,
   IsNumber,
   IsOptional,
@@ -7,14 +9,20 @@ import {
   IsString,
   Length,
   MaxLength,
-  Min,
+  ValidateNested,
 } from 'class-validator';
+import { ProductSizeWithStockDto } from './product-size.dto';
 
 // dto for creating product
 export class CreateProductDto {
-  @ApiProperty({ example: 'Футболка Slipknot Iowa', description: 'Название товара' })
+  @ApiProperty({
+    example: 'Футболка Slipknot Iowa',
+    description: 'Название товара',
+  })
   @IsString({ message: 'Название товара должно быть строкой' })
-  @Length(2, 200, { message: 'Название товара должно содержать от 2 до 200 символов' })
+  @Length(2, 200, {
+    message: 'Название товара должно содержать от 2 до 200 символов',
+  })
   title: string;
 
   @ApiPropertyOptional({
@@ -35,11 +43,6 @@ export class CreateProductDto {
   @Length(2, 100, { message: 'Артикул должен содержать от 2 до 100 символов' })
   sku: string;
 
-  @ApiProperty({ example: 20, description: 'Количество на складе' })
-  @IsInt({ message: 'Количество на складе должно быть целым числом' })
-  @Min(0, { message: 'Количество на складе не может быть отрицательным' })
-  stockCount: number;
-
   @ApiPropertyOptional({
     example: 'https://example.com/images/shirt.jpg',
     description: 'Ссылка на изображение товара',
@@ -55,8 +58,14 @@ export class CreateProductDto {
   @IsInt({ message: 'Идентификатор категории должен быть числом' })
   categoryId: number;
 
-  @ApiPropertyOptional({ example: 2, description: 'Идентификатор размера', nullable: true })
+  @ApiPropertyOptional({
+    type: () => ProductSizeWithStockDto,
+    isArray: true,
+    description: 'Размеры и остатки товара',
+  })
   @IsOptional()
-  @IsInt({ message: 'Идентификатор размера должен быть числом' })
-  sizeId?: number | null;
+  @IsArray({ message: 'Размеры должны быть массивом' })
+  @ValidateNested({ each: true })
+  @Type(() => ProductSizeWithStockDto)
+  sizes?: ProductSizeWithStockDto[];
 }

--- a/backend/src/modules/products/dto/product-response.dto.ts
+++ b/backend/src/modules/products/dto/product-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ProductSizeStockResponseDto } from './product-size.dto';
 
 export class ProductCategoryInfoDto {
   @ApiProperty({ example: 4, description: 'Идентификатор категории' })
@@ -8,20 +9,15 @@ export class ProductCategoryInfoDto {
   name: string;
 }
 
-export class ProductSizeInfoDto {
-  @ApiProperty({ example: 2, description: 'Идентификатор размера' })
-  id: number;
-
-  @ApiProperty({ example: 'L', description: 'Название размера' })
-  name: string;
-}
-
 // dto for returning product details
 export class ProductResponseDto {
   @ApiProperty({ example: 25, description: 'Идентификатор товара' })
   id: number;
 
-  @ApiProperty({ example: 'Футболка Slipknot Iowa', description: 'Название товара' })
+  @ApiProperty({
+    example: 'Футболка Slipknot Iowa',
+    description: 'Название товара',
+  })
   title: string;
 
   @ApiPropertyOptional({
@@ -37,17 +33,26 @@ export class ProductResponseDto {
   @ApiProperty({ example: 'SLP-TS-002', description: 'Артикул товара' })
   sku: string;
 
-  @ApiProperty({ example: 15, description: 'Остаток на складе' })
-  stockCount: number;
-
-  @ApiPropertyOptional({ example: 'https://example.com/images/shirt.jpg', description: 'Ссылка на изображение', nullable: true })
+  @ApiPropertyOptional({
+    example: 'https://example.com/images/shirt.jpg',
+    description: 'Ссылка на изображение',
+    nullable: true,
+  })
   imageUrl: string | null;
 
-  @ApiProperty({ type: () => ProductCategoryInfoDto, nullable: true, description: 'Категория товара' })
+  @ApiProperty({
+    type: () => ProductCategoryInfoDto,
+    nullable: true,
+    description: 'Категория товара',
+  })
   category: ProductCategoryInfoDto | null;
 
-  @ApiProperty({ type: () => ProductSizeInfoDto, nullable: true, description: 'Размер товара' })
-  size: ProductSizeInfoDto | null;
+  @ApiProperty({
+    type: () => ProductSizeStockResponseDto,
+    isArray: true,
+    description: 'Доступные размеры и остатки по каждому размеру',
+  })
+  sizes: ProductSizeStockResponseDto[];
 
   @ApiProperty({ description: 'Дата создания записи' })
   createdAt: Date;

--- a/backend/src/modules/products/dto/product-size.dto.ts
+++ b/backend/src/modules/products/dto/product-size.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsString, Length, Min } from 'class-validator';
+
+// dto describing size + stock payload for product creation/update
+export class ProductSizeWithStockDto {
+  @ApiProperty({ example: 'L', description: 'Название размера' })
+  @IsString({ message: 'Название размера должно быть строкой' })
+  @Length(1, 20, {
+    message: 'Название размера должно содержать от 1 до 20 символов',
+  })
+  size: string;
+
+  @ApiProperty({ example: 15, description: 'Количество товара на складе' })
+  @IsInt({ message: 'Количество должно быть целым числом' })
+  @Min(0, { message: 'Количество не может быть отрицательным' })
+  stock: number;
+}
+
+// dto describing size info returned to clients
+export class ProductSizeStockResponseDto {
+  @ApiProperty({ example: 42, description: 'Идентификатор размера товара' })
+  id: number;
+
+  @ApiProperty({ example: 'L', description: 'Название размера' })
+  size: string;
+
+  @ApiProperty({ example: 10, description: 'Текущее количество на складе' })
+  stock: number;
+
+  @ApiPropertyOptional({
+    example: 77,
+    description: 'Идентификатор записи склада (size_stock)',
+    nullable: true,
+  })
+  stockId: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Дата последнего обновления остатка',
+    nullable: true,
+  })
+  stockUpdatedAt: Date | null;
+}

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -1,5 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
+  IsArray,
   IsInt,
   IsNumber,
   IsOptional,
@@ -7,18 +9,27 @@ import {
   IsString,
   Length,
   MaxLength,
-  Min,
+  ValidateNested,
 } from 'class-validator';
+import { ProductSizeWithStockDto } from './product-size.dto';
 
 // dto for updating product
 export class UpdateProductDto {
-  @ApiPropertyOptional({ example: 'Футболка Slipknot 1999', description: 'Название товара' })
+  @ApiPropertyOptional({
+    example: 'Футболка Slipknot 1999',
+    description: 'Название товара',
+  })
   @IsOptional()
   @IsString({ message: 'Название товара должно быть строкой' })
-  @Length(2, 200, { message: 'Название товара должно содержать от 2 до 200 символов' })
+  @Length(2, 200, {
+    message: 'Название товара должно содержать от 2 до 200 символов',
+  })
   title?: string;
 
-  @ApiPropertyOptional({ example: 'Обновлённое описание товара', description: 'Описание товара' })
+  @ApiPropertyOptional({
+    example: 'Обновлённое описание товара',
+    description: 'Описание товара',
+  })
   @IsOptional()
   @IsString({ message: 'Описание должно быть строкой' })
   description?: string;
@@ -29,19 +40,19 @@ export class UpdateProductDto {
   @IsPositive({ message: 'Цена должна быть больше нуля' })
   price?: number;
 
-  @ApiPropertyOptional({ example: 'SLP-TS-002-NEW', description: 'Артикул товара' })
+  @ApiPropertyOptional({
+    example: 'SLP-TS-002-NEW',
+    description: 'Артикул товара',
+  })
   @IsOptional()
   @IsString({ message: 'Артикул должен быть строкой' })
   @Length(2, 100, { message: 'Артикул должен содержать от 2 до 100 символов' })
   sku?: string;
 
-  @ApiPropertyOptional({ example: 30, description: 'Количество на складе' })
-  @IsOptional()
-  @IsInt({ message: 'Количество на складе должно быть целым числом' })
-  @Min(0, { message: 'Количество на складе не может быть отрицательным' })
-  stockCount?: number;
-
-  @ApiPropertyOptional({ example: 'https://example.com/images/shirt-new.jpg', description: 'Ссылка на изображение товара' })
+  @ApiPropertyOptional({
+    example: 'https://example.com/images/shirt-new.jpg',
+    description: 'Ссылка на изображение товара',
+  })
   @IsOptional()
   @IsString({ message: 'Ссылка на изображение должна быть строкой' })
   @MaxLength(500, {
@@ -54,8 +65,14 @@ export class UpdateProductDto {
   @IsInt({ message: 'Идентификатор категории должен быть числом' })
   categoryId?: number;
 
-  @ApiPropertyOptional({ example: 2, description: 'Идентификатор размера', nullable: true })
+  @ApiPropertyOptional({
+    type: () => ProductSizeWithStockDto,
+    isArray: true,
+    description: 'Набор размеров и остатков (полностью заменяет текущие)',
+  })
   @IsOptional()
-  @IsInt({ message: 'Идентификатор размера должен быть числом' })
-  sizeId?: number | null;
+  @IsArray({ message: 'Размеры должны быть массивом' })
+  @ValidateNested({ each: true })
+  @Type(() => ProductSizeWithStockDto)
+  sizes?: ProductSizeWithStockDto[];
 }

--- a/backend/src/modules/products/entities/product-size.entity.ts
+++ b/backend/src/modules/products/entities/product-size.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Product } from './product.entity';
+import { SizeStock } from './size-stock.entity';
+import { CartItem } from '../../cart-items/entities/cart-item.entity';
+import { OrderItem } from '../../order-items/entities/order-item.entity';
+
+// entity describing individual size option for a product
+@Entity({ name: 'product_sizes' })
+export class ProductSize {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Product, (product) => product.productSizes, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+
+  @Column({ type: 'varchar', length: 20 })
+  size: string;
+
+  @OneToOne(() => SizeStock, (stock) => stock.size, {
+    cascade: true,
+  })
+  stock: SizeStock;
+
+  @OneToMany(() => CartItem, (cartItem) => cartItem.productSize)
+  cartItems: CartItem[];
+
+  @OneToMany(() => OrderItem, (orderItem) => orderItem.productSize)
+  orderItems: OrderItem[];
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/products/entities/product.entity.ts
+++ b/backend/src/modules/products/entities/product.entity.ts
@@ -13,7 +13,8 @@ import { ProductImage } from '../../product-images/entities/product-image.entity
 import { CartItem } from '../../cart-items/entities/cart-item.entity';
 import { OrderItem } from '../../order-items/entities/order-item.entity';
 import { WishlistItem } from '../../wishlist-items/entities/wishlist-item.entity';
-import { SizeEntity } from '../../sizes/entities/size.entity';
+import { ProductSize } from './product-size.entity';
+import { Review } from '../../reviews/entities/review.entity';
 
 // product entity
 @Entity({ name: 'products' })
@@ -34,18 +35,9 @@ export class Product {
   @Column({ type: 'numeric', precision: 10, scale: 2 })
   price: string;
 
-  // total quantity available for sale
-  @Column({ name: 'stock_count', type: 'integer', default: 0 })
-  stockCount: number;
-
   // url to the primary product image
   @Column({ name: 'image_url', type: 'text', nullable: true })
   imageUrl?: string | null;
-
-  // optional reference to a predefined size
-  @ManyToOne(() => SizeEntity, (size) => size.products, { nullable: true })
-  @JoinColumn({ name: 'size_id' })
-  size?: SizeEntity | null;
 
   @ManyToOne(() => Category, (category) => category.products)
   @JoinColumn({ name: 'category_id' })
@@ -53,6 +45,11 @@ export class Product {
 
   @OneToMany(() => ProductImage, (image) => image.product)
   images: ProductImage[];
+
+  @OneToMany(() => ProductSize, (productSize) => productSize.product, {
+    cascade: true,
+  })
+  productSizes: ProductSize[];
 
   @OneToMany(() => CartItem, (cartItem) => cartItem.product)
   cartItems: CartItem[];
@@ -62,6 +59,9 @@ export class Product {
 
   @OneToMany(() => WishlistItem, (wishlistItem) => wishlistItem.product)
   wishlistItems: WishlistItem[];
+
+  @OneToMany(() => Review, (review) => review.product)
+  reviews: Review[];
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
   createdAt: Date;

--- a/backend/src/modules/products/entities/size-stock.entity.ts
+++ b/backend/src/modules/products/entities/size-stock.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ProductSize } from './product-size.entity';
+
+// entity describing stock amount for a particular product size
+@Entity({ name: 'size_stock' })
+export class SizeStock {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @OneToOne(() => ProductSize, (productSize) => productSize.stock, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'size_id' })
+  size: ProductSize;
+
+  @Column({ type: 'integer' })
+  stock: number;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -23,6 +23,7 @@ import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { ProductResponseDto } from './dto/product-response.dto';
+import { ProductSizeStockResponseDto } from './dto/product-size.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -40,23 +41,46 @@ export class ProductsController {
   @ApiOperation({ summary: 'Создать новый товар' })
   @ApiCreatedResponse({ description: 'Товар создан', type: ProductResponseDto })
   @ApiBadRequestResponse({ description: 'Некорректные данные товара' })
-  create(@Body() createProductDto: CreateProductDto): Promise<ProductResponseDto> {
+  create(
+    @Body() createProductDto: CreateProductDto,
+  ): Promise<ProductResponseDto> {
     return this.productsService.create(createProductDto);
   }
 
   @Get()
   @ApiOperation({ summary: 'Получить список товаров' })
-  @ApiOkResponse({ description: 'Список товаров', type: ProductResponseDto, isArray: true })
+  @ApiOkResponse({
+    description: 'Список товаров',
+    type: ProductResponseDto,
+    isArray: true,
+  })
   findAll(): Promise<ProductResponseDto[]> {
     return this.productsService.findAll();
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Получить товар по идентификатору' })
-  @ApiOkResponse({ description: 'Детальная информация о товаре', type: ProductResponseDto })
+  @ApiOkResponse({
+    description: 'Детальная информация о товаре',
+    type: ProductResponseDto,
+  })
   @ApiNotFoundResponse({ description: 'Товар не найден' })
   findOne(@Param('id', ParseIntPipe) id: number): Promise<ProductResponseDto> {
     return this.productsService.findById(id);
+  }
+
+  @Get(':id/sizes')
+  @ApiOperation({ summary: 'Получить список размеров и остатков товара' })
+  @ApiOkResponse({
+    description: 'Размеры товара и их остатки',
+    type: ProductSizeStockResponseDto,
+    isArray: true,
+  })
+  @ApiNotFoundResponse({ description: 'Товар не найден' })
+  findSizes(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<ProductSizeStockResponseDto[]> {
+    return this.productsService.findSizes(id);
   }
 
   @Put(':id')

--- a/backend/src/modules/products/products.module.ts
+++ b/backend/src/modules/products/products.module.ts
@@ -4,11 +4,14 @@ import { Product } from './entities/product.entity';
 import { ProductsService } from './products.service';
 import { ProductsController } from './products.controller';
 import { Category } from '../categories/entities/category.entity';
-import { SizeEntity } from '../sizes/entities/size.entity';
+import { ProductSize } from './entities/product-size.entity';
+import { SizeStock } from './entities/size-stock.entity';
 
 // module for product operations
 @Module({
-  imports: [TypeOrmModule.forFeature([Product, Category, SizeEntity])],
+  imports: [
+    TypeOrmModule.forFeature([Product, Category, ProductSize, SizeStock]),
+  ],
   controllers: [ProductsController],
   providers: [ProductsService],
   exports: [ProductsService],

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -1,17 +1,23 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
 import { Category } from '../categories/entities/category.entity';
-import { SizeEntity } from '../sizes/entities/size.entity';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { ProductResponseDto } from './dto/product-response.dto';
+import {
+  ProductSizeStockResponseDto,
+  ProductSizeWithStockDto,
+} from './dto/product-size.dto';
+import { ProductSize } from './entities/product-size.entity';
+import { SizeStock } from './entities/size-stock.entity';
 
 // service with product management logic
 @Injectable()
@@ -23,49 +29,73 @@ export class ProductsService {
     private readonly productsRepository: Repository<Product>,
     @InjectRepository(Category)
     private readonly categoriesRepository: Repository<Category>,
-    @InjectRepository(SizeEntity)
-    private readonly sizesRepository: Repository<SizeEntity>,
+    private readonly dataSource: DataSource,
   ) {}
 
-  async create(createProductDto: CreateProductDto): Promise<ProductResponseDto> {
+  async create(
+    createProductDto: CreateProductDto,
+  ): Promise<ProductResponseDto> {
     const sku = createProductDto.sku.trim();
 
-    const existingSku = await this.productsRepository.findOne({
-      where: { sku },
+    return this.dataSource.transaction(async (manager) => {
+      const productsRepo = manager.getRepository(Product);
+
+      const existingSku = await productsRepo.findOne({ where: { sku } });
+
+      if (existingSku) {
+        throw new ConflictException('Товар с таким артикулом уже существует');
+      }
+
+      const category = await this.findCategoryById(
+        createProductDto.categoryId,
+        manager,
+      );
+
+      const product = productsRepo.create({
+        title: createProductDto.title.trim(),
+        description: createProductDto.description?.trim() ?? null,
+        price: createProductDto.price.toFixed(2),
+        sku,
+        imageUrl: createProductDto.imageUrl?.trim() ?? null,
+        category,
+      });
+
+      const saved = await productsRepo.save(product);
+
+      const normalizedSizes = this.normalizeSizePayload(createProductDto.sizes);
+      await this.createProductSizes(manager, saved, normalizedSizes);
+
+      const productWithRelations = await productsRepo.findOne({
+        where: { id: saved.id },
+        relations: {
+          category: true,
+          productSizes: { stock: true },
+        },
+        order: {
+          productSizes: { size: 'ASC' },
+        },
+      });
+
+      if (!productWithRelations) {
+        throw new NotFoundException('Товар не найден после сохранения');
+      }
+
+      return this.toProductResponse(productWithRelations);
     });
-
-    if (existingSku) {
-      throw new ConflictException('Товар с таким артикулом уже существует');
-    }
-
-    const category = await this.findCategoryById(createProductDto.categoryId);
-
-    const size =
-      createProductDto.sizeId !== undefined && createProductDto.sizeId !== null
-        ? await this.findSizeById(createProductDto.sizeId)
-        : null;
-
-    const product = this.productsRepository.create({
-      title: createProductDto.title.trim(),
-      description: createProductDto.description?.trim() ?? null,
-      price: createProductDto.price.toFixed(2),
-      sku,
-      stockCount: createProductDto.stockCount,
-      imageUrl: createProductDto.imageUrl?.trim() ?? null,
-      category,
-      size: size ?? null,
-    });
-
-    const saved = await this.productsRepository.save(product);
-    return this.findById(saved.id);
   }
 
   async findAll(): Promise<ProductResponseDto[]> {
     this.logger.log('Запрос каталога товаров');
     try {
       const products = await this.productsRepository.find({
-        relations: { category: true, size: true },
-        order: { id: 'ASC' },
+        relations: {
+          category: true,
+          productSizes: { stock: true },
+        },
+        order: {
+          id: 'ASC',
+          productSizes: { size: 'ASC' },
+        },
       });
 
       this.logger.log(`Каталог успешно загружен (${products.length} позиций)`);
@@ -81,7 +111,13 @@ export class ProductsService {
   async findById(id: number): Promise<ProductResponseDto> {
     const product = await this.productsRepository.findOne({
       where: { id },
-      relations: { category: true, size: true },
+      relations: {
+        category: true,
+        productSizes: { stock: true },
+      },
+      order: {
+        productSizes: { size: 'ASC' },
+      },
     });
 
     if (!product) {
@@ -91,62 +127,102 @@ export class ProductsService {
     return this.toProductResponse(product);
   }
 
-  async update(id: number, updateProductDto: UpdateProductDto): Promise<ProductResponseDto> {
+  async findSizes(id: number): Promise<ProductSizeStockResponseDto[]> {
     const product = await this.productsRepository.findOne({
       where: { id },
-      relations: { category: true, size: true },
+      relations: {
+        productSizes: { stock: true },
+      },
+      order: {
+        productSizes: { size: 'ASC' },
+      },
     });
 
     if (!product) {
       throw new NotFoundException('Товар не найден');
     }
 
-    if (updateProductDto.sku) {
-      const sku = updateProductDto.sku.trim();
-      if (sku !== product.sku) {
-        const existingSku = await this.productsRepository.findOne({
-          where: { sku },
-        });
-        if (existingSku && existingSku.id !== product.id) {
-          throw new ConflictException('Товар с таким артикулом уже существует');
-        }
-        product.sku = sku;
+    return (product.productSizes ?? []).map((size) =>
+      this.toProductSizeResponse(size),
+    );
+  }
+
+  async update(
+    id: number,
+    updateProductDto: UpdateProductDto,
+  ): Promise<ProductResponseDto> {
+    return this.dataSource.transaction(async (manager) => {
+      const productsRepo = manager.getRepository(Product);
+
+      const product = await productsRepo.findOne({
+        where: { id },
+        relations: {
+          category: true,
+          productSizes: { stock: true },
+        },
+      });
+
+      if (!product) {
+        throw new NotFoundException('Товар не найден');
       }
-    }
 
-    if (updateProductDto.title) {
-      product.title = updateProductDto.title.trim();
-    }
+      if (updateProductDto.sku) {
+        const sku = updateProductDto.sku.trim();
+        if (sku !== product.sku) {
+          const existingSku = await productsRepo.findOne({ where: { sku } });
+          if (existingSku && existingSku.id !== product.id) {
+            throw new ConflictException(
+              'Товар с таким артикулом уже существует',
+            );
+          }
+          product.sku = sku;
+        }
+      }
 
-    if (updateProductDto.description !== undefined) {
-      product.description = updateProductDto.description?.trim() ?? null;
-    }
+      if (updateProductDto.title) {
+        product.title = updateProductDto.title.trim();
+      }
 
-    if (updateProductDto.price !== undefined) {
-      product.price = updateProductDto.price.toFixed(2);
-    }
+      if (updateProductDto.description !== undefined) {
+        product.description = updateProductDto.description?.trim() ?? null;
+      }
 
-    if (updateProductDto.stockCount !== undefined) {
-      product.stockCount = updateProductDto.stockCount;
-    }
+      if (updateProductDto.price !== undefined) {
+        product.price = updateProductDto.price.toFixed(2);
+      }
 
-    if (updateProductDto.imageUrl !== undefined) {
-      product.imageUrl = updateProductDto.imageUrl?.trim() ?? null;
-    }
+      if (updateProductDto.imageUrl !== undefined) {
+        product.imageUrl = updateProductDto.imageUrl?.trim() ?? null;
+      }
 
-    if (updateProductDto.categoryId !== undefined) {
-      product.category = await this.findCategoryById(updateProductDto.categoryId);
-    }
+      if (updateProductDto.categoryId !== undefined) {
+        product.category = await this.findCategoryById(
+          updateProductDto.categoryId,
+          manager,
+        );
+      }
 
-    if (updateProductDto.sizeId !== undefined) {
-      product.size =
-        updateProductDto.sizeId === null
-          ? null
-          : await this.findSizeById(updateProductDto.sizeId);
-    }
+      await productsRepo.save(product);
 
-    const saved = await this.productsRepository.save(product);
-    return this.findById(saved.id);
+      await this.replaceProductSizes(manager, product, updateProductDto.sizes);
+
+      const reloaded = await productsRepo.findOne({
+        where: { id: product.id },
+        relations: {
+          category: true,
+          productSizes: { stock: true },
+        },
+        order: {
+          productSizes: { size: 'ASC' },
+        },
+      });
+
+      if (!reloaded) {
+        throw new NotFoundException('Товар не найден после обновления');
+      }
+
+      return this.toProductResponse(reloaded);
+    });
   }
 
   async remove(id: number): Promise<void> {
@@ -159,24 +235,21 @@ export class ProductsService {
     await this.productsRepository.remove(product);
   }
 
-  private async findCategoryById(id: number): Promise<Category> {
-    const category = await this.categoriesRepository.findOne({ where: { id } });
+  private async findCategoryById(
+    id: number,
+    manager?: EntityManager,
+  ): Promise<Category> {
+    const repository = manager
+      ? manager.getRepository(Category)
+      : this.categoriesRepository;
+
+    const category = await repository.findOne({ where: { id } });
 
     if (!category) {
       throw new NotFoundException('Категория не найдена');
     }
 
     return category;
-  }
-
-  private async findSizeById(id: number): Promise<SizeEntity> {
-    const size = await this.sizesRepository.findOne({ where: { id } });
-
-    if (!size) {
-      throw new NotFoundException('Размер не найден');
-    }
-
-    return size;
   }
 
   private toProductResponse(product: Product): ProductResponseDto {
@@ -186,7 +259,6 @@ export class ProductsService {
       description: product.description ?? null,
       price: Number(product.price),
       sku: product.sku,
-      stockCount: product.stockCount,
       imageUrl: product.imageUrl ?? null,
       category: product.category
         ? {
@@ -194,14 +266,99 @@ export class ProductsService {
             name: product.category.name,
           }
         : null,
-      size: product.size
-        ? {
-            id: product.size.id,
-            name: product.size.name,
-          }
-        : null,
+      sizes: (product.productSizes ?? []).map((size) =>
+        this.toProductSizeResponse(size),
+      ),
       createdAt: product.createdAt,
       updatedAt: product.updatedAt,
     };
+  }
+
+  private toProductSizeResponse(
+    productSize: ProductSize,
+  ): ProductSizeStockResponseDto {
+    return {
+      id: productSize.id,
+      size: productSize.size,
+      stock: productSize.stock?.stock ?? 0,
+      stockId: productSize.stock?.id ?? null,
+      stockUpdatedAt: productSize.stock?.updatedAt ?? null,
+    };
+  }
+
+  private normalizeSizePayload(
+    sizes?: ProductSizeWithStockDto[],
+  ): { size: string; stock: number }[] {
+    if (!sizes || sizes.length === 0) {
+      return [];
+    }
+
+    const normalized: { size: string; stock: number }[] = [];
+    const seen = new Set<string>();
+
+    for (const size of sizes) {
+      const trimmed = size.size.trim();
+      if (!trimmed) {
+        throw new BadRequestException('Название размера не может быть пустым');
+      }
+
+      const key = trimmed.toLowerCase();
+      if (seen.has(key)) {
+        throw new BadRequestException('Размеры не должны повторяться');
+      }
+
+      seen.add(key);
+      normalized.push({ size: trimmed, stock: size.stock });
+    }
+
+    return normalized;
+  }
+
+  private async createProductSizes(
+    manager: EntityManager,
+    product: Product,
+    sizes: { size: string; stock: number }[],
+  ): Promise<void> {
+    if (!sizes.length) {
+      return;
+    }
+
+    const productSizesRepo = manager.getRepository(ProductSize);
+    const sizeStockRepo = manager.getRepository(SizeStock);
+
+    for (const { size, stock } of sizes) {
+      const productSize = productSizesRepo.create({
+        product,
+        size,
+      });
+      const savedSize = await productSizesRepo.save(productSize);
+
+      const stockEntity = sizeStockRepo.create({
+        size: savedSize,
+        stock,
+      });
+      await sizeStockRepo.save(stockEntity);
+    }
+  }
+
+  private async replaceProductSizes(
+    manager: EntityManager,
+    product: Product,
+    sizes?: ProductSizeWithStockDto[],
+  ): Promise<void> {
+    if (sizes === undefined) {
+      return;
+    }
+
+    const productSizesRepo = manager.getRepository(ProductSize);
+
+    await productSizesRepo
+      .createQueryBuilder()
+      .delete()
+      .where('product_id = :productId', { productId: product.id })
+      .execute();
+
+    const normalized = this.normalizeSizePayload(sizes);
+    await this.createProductSizes(manager, product, normalized);
   }
 }

--- a/backend/src/modules/reviews/dto/create-review.dto.ts
+++ b/backend/src/modules/reviews/dto/create-review.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+// dto for creating a new review by authenticated user
+export class CreateReviewDto {
+  @ApiProperty({ example: 15, description: 'Идентификатор товара' })
+  @IsInt({ message: 'Идентификатор товара должен быть числом' })
+  productId: number;
+
+  @ApiProperty({ example: 5, description: 'Оценка товара от 1 до 5' })
+  @IsInt({ message: 'Оценка должна быть целым числом' })
+  @Min(1, { message: 'Оценка не может быть меньше 1' })
+  @Max(5, { message: 'Оценка не может быть больше 5' })
+  rating: number;
+
+  @ApiPropertyOptional({
+    example: 'Отличное качество мерча!',
+    description: 'Текстовый комментарий к отзыву',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString({ message: 'Комментарий должен быть строкой' })
+  @MaxLength(2000, {
+    message: 'Комментарий должен содержать не более 2000 символов',
+  })
+  comment?: string;
+}

--- a/backend/src/modules/reviews/dto/review-response.dto.ts
+++ b/backend/src/modules/reviews/dto/review-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+class ReviewAuthorDto {
+  @ApiProperty({ example: 7, description: 'Идентификатор автора отзыва' })
+  id: number;
+
+  @ApiProperty({ example: 'Кори Тейлор', description: 'Имя автора отзыва' })
+  name: string;
+}
+
+// dto returned when reading reviews
+export class ReviewResponseDto {
+  @ApiProperty({ example: 21, description: 'Идентификатор отзыва' })
+  id: number;
+
+  @ApiProperty({ example: 5, description: 'Оценка товара' })
+  rating: number;
+
+  @ApiPropertyOptional({
+    example: 'Футболка просто огонь!',
+    description: 'Комментарий к отзыву',
+    nullable: true,
+  })
+  comment: string | null;
+
+  @ApiProperty({ example: 'pending', description: 'Статус модерации отзыва' })
+  status: string;
+
+  @ApiProperty({ example: 10, description: 'Идентификатор товара' })
+  productId: number;
+
+  @ApiProperty({ type: () => ReviewAuthorDto, description: 'Автор отзыва' })
+  author: ReviewAuthorDto;
+
+  @ApiProperty({ description: 'Дата создания отзыва' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Дата последнего обновления отзыва' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/reviews/entities/review.entity.ts
+++ b/backend/src/modules/reviews/entities/review.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Product } from '../../products/entities/product.entity';
+
+// entity representing user review for a product
+@Entity({ name: 'reviews' })
+export class Review {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.reviews, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Product, (product) => product.reviews, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+
+  @Column({ type: 'integer' })
+  rating: number;
+
+  @Column({ type: 'text', nullable: true })
+  comment?: string | null;
+
+  @Column({ type: 'varchar', length: 16, default: 'pending' })
+  status: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/reviews/reviews.controller.ts
+++ b/backend/src/modules/reviews/reviews.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { ReviewsService } from './reviews.service';
+import { CreateReviewDto } from './dto/create-review.dto';
+import { ReviewResponseDto } from './dto/review-response.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+interface AuthenticatedRequest extends Request {
+  user?: { userId?: number; id?: number };
+}
+
+// controller exposing review endpoints
+@ApiTags('Отзывы')
+@Controller('reviews')
+export class ReviewsController {
+  constructor(private readonly reviewsService: ReviewsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Создать отзыв о товаре' })
+  @ApiCreatedResponse({ description: 'Отзыв создан', type: ReviewResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Пользователь не авторизован' })
+  @ApiBadRequestResponse({ description: 'Некорректные данные отзыва' })
+  @ApiConflictResponse({ description: 'Отзыв на товар уже существует' })
+  async create(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreateReviewDto,
+  ): Promise<ReviewResponseDto> {
+    const userId = req.user?.userId ?? req.user?.id;
+    if (!userId) {
+      throw new UnauthorizedException('Требуется авторизация');
+    }
+
+    return this.reviewsService.create(userId, dto);
+  }
+
+  @Get(':productId')
+  @ApiOperation({ summary: 'Получить список подтверждённых отзывов товара' })
+  @ApiOkResponse({
+    description: 'Список отзывов по товару',
+    type: ReviewResponseDto,
+    isArray: true,
+  })
+  @ApiNotFoundResponse({ description: 'Товар не найден' })
+  async findForProduct(
+    @Param('productId', ParseIntPipe) productId: number,
+  ): Promise<ReviewResponseDto[]> {
+    return this.reviewsService.findForProduct(productId);
+  }
+}

--- a/backend/src/modules/reviews/reviews.module.ts
+++ b/backend/src/modules/reviews/reviews.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReviewsController } from './reviews.controller';
+import { ReviewsService } from './reviews.service';
+import { Review } from './entities/review.entity';
+import { Product } from '../products/entities/product.entity';
+import { User } from '../users/entities/user.entity';
+
+// module bundling review functionality
+@Module({
+  imports: [TypeOrmModule.forFeature([Review, Product, User])],
+  controllers: [ReviewsController],
+  providers: [ReviewsService],
+  exports: [ReviewsService],
+})
+export class ReviewsModule {}

--- a/backend/src/modules/reviews/reviews.service.ts
+++ b/backend/src/modules/reviews/reviews.service.ts
@@ -1,0 +1,116 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import { CreateReviewDto } from './dto/create-review.dto';
+import { ReviewResponseDto } from './dto/review-response.dto';
+import { Review } from './entities/review.entity';
+import { Product } from '../products/entities/product.entity';
+import { User } from '../users/entities/user.entity';
+
+// service implementing review creation and retrieval logic
+@Injectable()
+export class ReviewsService {
+  constructor(
+    @InjectRepository(Review)
+    private readonly reviewsRepository: Repository<Review>,
+    @InjectRepository(Product)
+    private readonly productsRepository: Repository<Product>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async create(
+    userId: number,
+    dto: CreateReviewDto,
+  ): Promise<ReviewResponseDto> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('Пользователь не найден');
+    }
+
+    const product = await this.productsRepository.findOne({
+      where: { id: dto.productId },
+    });
+
+    if (!product) {
+      throw new NotFoundException('Товар не найден');
+    }
+
+    const comment = dto.comment?.trim();
+
+    const review = this.reviewsRepository.create({
+      user,
+      product,
+      rating: dto.rating,
+      comment: comment && comment.length ? comment : null,
+      status: 'pending',
+    });
+
+    try {
+      const saved = await this.reviewsRepository.save(review);
+      const loaded = await this.reviewsRepository.findOne({
+        where: { id: saved.id },
+        relations: { user: true, product: true },
+      });
+
+      if (!loaded) {
+        throw new NotFoundException('Не удалось загрузить созданный отзыв');
+      }
+
+      return this.toReviewResponse(loaded);
+    } catch (error) {
+      const driverError =
+        error instanceof QueryFailedError
+          ? error.driverError
+          : (error as { driverError?: { code?: string } }).driverError;
+
+      if (driverError?.code === '23505') {
+        throw new ConflictException('Вы уже оставили отзыв на данный товар');
+      }
+
+      throw error;
+    }
+  }
+
+  async findForProduct(productId: number): Promise<ReviewResponseDto[]> {
+    const product = await this.productsRepository.findOne({
+      where: { id: productId },
+    });
+
+    if (!product) {
+      throw new NotFoundException('Товар не найден');
+    }
+
+    const reviews = await this.reviewsRepository.find({
+      where: { product: { id: productId }, status: 'approved' },
+      relations: { user: true },
+      order: { createdAt: 'DESC' },
+    });
+
+    return reviews.map((review) => this.toReviewResponse(review, productId));
+  }
+
+  private toReviewResponse(
+    review: Review,
+    productId?: number,
+  ): ReviewResponseDto {
+    return {
+      id: review.id,
+      rating: review.rating,
+      comment: review.comment ?? null,
+      status: review.status,
+      productId: productId ?? review.product?.id ?? 0,
+      author: {
+        id: review.user?.id ?? 0,
+        name: review.user?.name ?? 'Неизвестный пользователь',
+      },
+      createdAt: review.createdAt,
+      updatedAt: review.updatedAt,
+    };
+  }
+}

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -14,6 +14,7 @@ import { UserAddress } from '../../user-addresses/entities/user-address.entity';
 import { Order } from '../../orders/entities/order.entity';
 import { Cart } from '../../carts/entities/cart.entity';
 import { Wishlist } from '../../wishlists/entities/wishlist.entity';
+import { Review } from '../../reviews/entities/review.entity';
 
 // user entity
 @Entity({ name: 'users' })
@@ -57,6 +58,9 @@ export class User {
 
   @OneToOne(() => Wishlist, (wishlist) => wishlist.user)
   wishlist: Wishlist;
+
+  @OneToMany(() => Review, (review) => review.user)
+  reviews: Review[];
 
   @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
   createdAt: Date;


### PR DESCRIPTION
## Summary
- add product-level size and stock entities, DTOs, and the GET /products/:id/sizes endpoint
- update cart and order entities/services so line items track the chosen product size
- introduce the reviews module with POST /reviews and GET /reviews/:productId plus audit/boot wiring and a new task log

## Testing
- npx eslint src/modules/products src/modules/carts src/modules/orders src/modules/reviews src/modules/cart-items/entities/cart-item.entity.ts src/modules/order-items/entities/order-item.entity.ts src/modules/users/entities/user.entity.ts src/common/audit/audit.subscriber.ts src/app.module.ts


------
https://chatgpt.com/codex/tasks/task_e_68f12e71882483219f4a59a0ce243a1a