### PR TITLE
Add size-dependent pricing across backend and frontend

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -112,6 +112,7 @@ CREATE TABLE IF NOT EXISTS product_sizes (
     id SERIAL PRIMARY KEY,
     product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
     size VARCHAR(20) NOT NULL,
+    price NUMERIC(10, 2) NOT NULL CHECK (price >= 0),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     UNIQUE (product_id, size)
@@ -634,20 +635,21 @@ upserted_products AS (
 SELECT 1;
 
 WITH size_data AS (
-    SELECT 'SKU-TSHIRT-001'::text AS sku, 'S'::text AS size, 12::integer AS stock UNION ALL
-    SELECT 'SKU-TSHIRT-001', 'M', 18 UNION ALL
-    SELECT 'SKU-TSHIRT-001', 'L', 15 UNION ALL
-    SELECT 'SKU-HOODIE-002', 'M', 14 UNION ALL
-    SELECT 'SKU-HOODIE-002', 'L', 10 UNION ALL
-    SELECT 'SKU-HOODIE-002', 'XL', 8
+    SELECT 'SKU-TSHIRT-001'::text AS sku, 'S'::text AS size, 12::integer AS stock, 2990.00::numeric(10, 2) AS price UNION ALL
+    SELECT 'SKU-TSHIRT-001', 'M', 18, 3090.00 UNION ALL
+    SELECT 'SKU-TSHIRT-001', 'L', 15, 3190.00 UNION ALL
+    SELECT 'SKU-HOODIE-002', 'M', 14, 5490.00 UNION ALL
+    SELECT 'SKU-HOODIE-002', 'L', 10, 5690.00 UNION ALL
+    SELECT 'SKU-HOODIE-002', 'XL', 8, 5890.00
 )
-INSERT INTO product_sizes (product_id, size)
+INSERT INTO product_sizes (product_id, size, price)
 SELECT DISTINCT
     p.id,
-    sd.size
+    sd.size,
+    sd.price
 FROM size_data sd
 JOIN products p ON p.sku = sd.sku
-ON CONFLICT (product_id, size) DO UPDATE SET updated_at = NOW();
+ON CONFLICT (product_id, size) DO UPDATE SET price = EXCLUDED.price, updated_at = NOW();
 
 WITH size_data AS (
     SELECT 'SKU-TSHIRT-001'::text AS sku, 'S'::text AS size, 12::integer AS stock UNION ALL

--- a/backend/src/modules/carts/dto/cart-item-response.dto.ts
+++ b/backend/src/modules/carts/dto/cart-item-response.dto.ts
@@ -10,7 +10,10 @@ class CartItemProductDto {
   })
   title: string;
 
-  @ApiProperty({ example: 2990, description: 'Цена товара' })
+  @ApiProperty({
+    example: 3190,
+    description: 'Текущая цена товара с учётом выбранного размера',
+  })
   price: number;
 
   @ApiPropertyOptional({
@@ -30,6 +33,12 @@ class CartItemSizeDto {
 
   @ApiProperty({ example: 'L', description: 'Название выбранного размера' })
   size: string;
+
+  @ApiProperty({
+    example: 3190,
+    description: 'Цена для выбранного размера',
+  })
+  price: number;
 
   @ApiProperty({
     example: 8,

--- a/backend/src/modules/products/dto/product-response.dto.ts
+++ b/backend/src/modules/products/dto/product-response.dto.ts
@@ -27,7 +27,10 @@ export class ProductResponseDto {
   })
   description: string | null;
 
-  @ApiProperty({ example: 2990, description: 'Цена товара' })
+  @ApiProperty({
+    example: 2990,
+    description: 'Базовая цена товара (минимальная среди размеров)',
+  })
   price: number;
 
   @ApiProperty({ example: 'SLP-TS-002', description: 'Артикул товара' })

--- a/backend/src/modules/products/dto/product-size.dto.ts
+++ b/backend/src/modules/products/dto/product-size.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsString, Length, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNumber,
+  IsPositive,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
 
 // dto describing size + stock payload for product creation/update
 export class ProductSizeWithStockDto {
@@ -9,6 +16,11 @@ export class ProductSizeWithStockDto {
     message: 'Название размера должно содержать от 1 до 20 символов',
   })
   size: string;
+
+  @ApiProperty({ example: 3190, description: 'Цена для выбранного размера' })
+  @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Цена должна быть числом' })
+  @IsPositive({ message: 'Цена должна быть больше нуля' })
+  price: number;
 
   @ApiProperty({ example: 15, description: 'Количество товара на складе' })
   @IsInt({ message: 'Количество должно быть целым числом' })
@@ -23,6 +35,9 @@ export class ProductSizeStockResponseDto {
 
   @ApiProperty({ example: 'L', description: 'Название размера' })
   size: string;
+
+  @ApiProperty({ example: 3190, description: 'Цена выбранного размера' })
+  price: number;
 
   @ApiProperty({ example: 10, description: 'Текущее количество на складе' })
   stock: number;

--- a/backend/src/modules/products/entities/product-size.entity.ts
+++ b/backend/src/modules/products/entities/product-size.entity.ts
@@ -29,6 +29,9 @@ export class ProductSize {
   @Column({ type: 'varchar', length: 20 })
   size: string;
 
+  @Column({ type: 'numeric', precision: 10, scale: 2 })
+  price: string;
+
   @OneToOne(() => SizeStock, (stock) => stock.size, {
     cascade: true,
   })

--- a/frontend/src/api/cart.ts
+++ b/frontend/src/api/cart.ts
@@ -18,6 +18,7 @@ export interface CartItemDto {
 export interface CartItemSizeDto {
   id: number;
   size: string;
+  price: number;
   stock: number;
 }
 

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -21,6 +21,7 @@ export interface ProductDto {
 export interface ProductSizeDto {
   id: number;
   size: string;
+  price: number;
   stock: number;
   stockId: number | null;
   stockUpdatedAt: string | null;
@@ -28,6 +29,7 @@ export interface ProductSizeDto {
 
 export interface ProductSizePayload {
   size: string;
+  price: number;
   stock: number;
 }
 

--- a/frontend/src/components/ProductCard.vue
+++ b/frontend/src/components/ProductCard.vue
@@ -9,7 +9,7 @@
       <p class="product-card__category">{{ product.category?.name ?? 'Категория не указана' }}</p>
       <p class="product-card__description">{{ product.description ?? 'Описание появится позже' }}</p>
       <div class="product-card__footer">
-        <span class="product-card__price">{{ product.price.toLocaleString('ru-RU') }} ₽</span>
+        <span class="product-card__price">{{ priceLabel }}</span>
         <div class="product-card__actions">
           <slot name="actions"></slot>
         </div>
@@ -19,11 +19,20 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { ProductDto } from '../api/products';
 
-defineProps<{
+const props = defineProps<{
   product: ProductDto;
 }>();
+
+const priceLabel = computed(() => {
+  const formatted = props.product.price.toLocaleString('ru-RU');
+  if (props.product.sizes.length) {
+    return `от ${formatted} ₽`;
+  }
+  return `${formatted} ₽`;
+});
 </script>
 
 <style scoped>

--- a/frontend/src/pages/CartView.vue
+++ b/frontend/src/pages/CartView.vue
@@ -27,8 +27,12 @@
               <div v-else class="cart-item__placeholder">Фото</div>
               <div class="cart-item__content">
                 <h2 class="cart-item__title">{{ item.product.title }}</h2>
-                <p class="cart-item__meta">Цена: {{ formatCurrency(item.product.price) }}</p>
-                <p v-if="item.size" class="cart-item__meta">Размер: {{ item.size.size }}</p>
+                <p class="cart-item__meta">
+                  Цена: {{ formatCurrency(item.unitPrice) }}
+                </p>
+                <p v-if="item.size" class="cart-item__meta">
+                  Размер: {{ item.size.size }} — {{ formatCurrency(item.size.price) }}
+                </p>
                 <p v-if="item.size" class="cart-item__stock">Остаток: {{ item.size.stock }} шт.</p>
                 <div class="cart-item__controls">
                   <span class="cart-item__label">Количество</span>

--- a/frontend/src/pages/CheckoutPaymentPage.vue
+++ b/frontend/src/pages/CheckoutPaymentPage.vue
@@ -39,7 +39,12 @@
                 <div v-else class="checkout-item__placeholder">Фото</div>
                 <div class="checkout-item__content">
                   <h2 class="checkout-item__title">{{ item.product.title }}</h2>
-                  <p class="checkout-item__price">Цена: {{ formatCurrency(item.product.price) }}</p>
+                  <p class="checkout-item__price">
+                    Цена: {{ formatCurrency(item.unitPrice) }}
+                  </p>
+                  <p v-if="item.size" class="checkout-item__meta">
+                    Размер: {{ item.size.size }} — {{ formatCurrency(item.size.price) }}
+                  </p>
                   <p class="checkout-item__meta">Количество: {{ item.quantity }}</p>
                 </div>
               </article>

--- a/frontend/src/pages/ProductPage.vue
+++ b/frontend/src/pages/ProductPage.vue
@@ -44,6 +44,7 @@
                   @click="selectSize(size.id)"
                 >
                   <span class="product-sizes__label">{{ size.size }}</span>
+                  <span class="product-sizes__price">{{ formatCurrency(size.price) }}</span>
                   <small class="product-sizes__stock">Остаток: {{ size.stock }}</small>
                 </button>
               </div>
@@ -65,7 +66,7 @@
               <p class="product-details__stock">Универсальный размер, доступен для заказа.</p>
             </div>
             <div class="product-details__actions">
-              <span class="product-details__price">{{ product.price.toLocaleString('ru-RU') }} ₽</span>
+              <span class="product-details__price">{{ formatCurrency(displayPrice) }}</span>
               <div class="product-details__buttons">
                 <button
                   class="btn btn-danger btn-lg"
@@ -247,7 +248,7 @@
             <section class="modal-body">
               <p class="mb-3">
                 Вы собираетесь оформить заказ на товар «{{ product?.title }}» стоимостью
-                {{ product ? product.price.toLocaleString('ru-RU') : '' }} ₽.
+                {{ product ? formatCurrency(displayPrice) : '' }}.
               </p>
               <p v-if="selectedSize" class="text-muted mb-3">
                 Выбранный размер: {{ selectedSize.size }}
@@ -332,6 +333,9 @@ const hasAvailableSizes = computed(() =>
 const selectedSize = computed(() =>
   availableSizes.value.find((size) => size.id === selectedSizeId.value) ?? null,
 );
+const displayPrice = computed(() =>
+  selectedSize.value?.price ?? product.value?.price ?? 0,
+);
 const isOutOfStock = computed(() => {
   if (!hasSizes.value) {
     return false;
@@ -353,6 +357,8 @@ const selectSize = (sizeId: number) => {
   }
   selectedSizeId.value = sizeId;
 };
+
+const formatCurrency = (value: number) => `${value.toLocaleString('ru-RU')} ₽`;
 
 const productReviews = computed(() => {
   const id = product.value?.id;
@@ -692,6 +698,13 @@ const submitReview = async () => {
 .product-sizes__label {
   font-weight: 600;
   letter-spacing: 0.08em;
+}
+
+.product-sizes__price {
+  display: block;
+  font-weight: 600;
+  margin-top: 0.2rem;
+  color: var(--color-text);
 }
 
 .product-sizes__stock {


### PR DESCRIPTION
## Summary
- add a price column to `product_sizes` and seed size tiers for sample products
- update product and cart services to surface size-specific prices and adjust base pricing
- refresh product, cart, checkout, and manager UIs to select sizes and display the correct price per size

## Testing
- npm run lint (backend)
- npm run build *(fails: Rollup cannot resolve chart.js/auto)*


------
https://chatgpt.com/codex/tasks/task_e_68f2150101508321b0f90110e4cdcbbd