### PR TITLE
Align order history cards with site theme

### DIFF
--- a/backend/src/modules/orders/dto/customer-order-response.dto.ts
+++ b/backend/src/modules/orders/dto/customer-order-response.dto.ts
@@ -11,6 +11,49 @@ class CustomerOrderStatusDto {
   name: string;
 }
 
+class CustomerOrderItemProductDto {
+  @ApiProperty({ example: 7, description: 'Идентификатор товара' })
+  id: number;
+
+  @ApiProperty({ example: 'Футболка Slipknot', description: 'Название товара' })
+  title: string;
+
+  @ApiProperty({ example: 'SLP-TS-001', description: 'Артикул товара' })
+  sku: string;
+}
+
+class CustomerOrderItemSizeDto {
+  @ApiProperty({ example: 12, description: 'Идентификатор размера товара' })
+  id: number;
+
+  @ApiProperty({ example: 'L', description: 'Выбранный размер товара' })
+  size: string;
+}
+
+class CustomerOrderItemResponseDto {
+  @ApiProperty({ example: 42, description: 'Идентификатор позиции заказа' })
+  id: number;
+
+  @ApiProperty({
+    type: () => CustomerOrderItemProductDto,
+    description: 'Краткая информация о товаре',
+  })
+  product: CustomerOrderItemProductDto;
+
+  @ApiPropertyOptional({
+    type: () => CustomerOrderItemSizeDto,
+    nullable: true,
+    description: 'Информация о выбранном размере',
+  })
+  size: CustomerOrderItemSizeDto | null;
+
+  @ApiProperty({ example: 2, description: 'Количество товара в заказе' })
+  quantity: number;
+
+  @ApiProperty({ example: 2990, description: 'Стоимость единицы товара' })
+  unitPrice: number;
+}
+
 // dto describing order information in customer history
 export class CustomerOrderResponseDto {
   @ApiProperty({ example: 42, description: 'Идентификатор заказа' })
@@ -43,4 +86,11 @@ export class CustomerOrderResponseDto {
 
   @ApiProperty({ description: 'Дата оформления заказа' })
   placedAt: Date;
+
+  @ApiProperty({
+    description: 'Позиции, включенные в заказ',
+    type: () => CustomerOrderItemResponseDto,
+    isArray: true,
+  })
+  items: CustomerOrderItemResponseDto[];
 }

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -160,7 +160,7 @@ export class OrdersService {
   async findForUser(userId: number): Promise<CustomerOrderResponseDto[]> {
     const orders = await this.ordersRepository.find({
       where: { user: { id: userId } },
-      relations: { status: true },
+      relations: { status: true, items: { product: true, productSize: true } },
       order: { placedAt: 'DESC', id: 'DESC' },
     });
 
@@ -207,8 +207,8 @@ export class OrdersService {
     return address;
   }
 
-  private toOrderResponse(order: Order): OrderResponseDto {
-    const items: OrderItemResponseDto[] = (order.items ?? []).map((item) => ({
+  private mapOrderItems(order: Order): OrderItemResponseDto[] {
+    return (order.items ?? []).map((item) => ({
       id: item.id,
       product: {
         id: item.product?.id ?? 0,
@@ -224,6 +224,10 @@ export class OrdersService {
       quantity: item.quantity,
       unitPrice: Number(item.unitPrice),
     }));
+  }
+
+  private toOrderResponse(order: Order): OrderResponseDto {
+    const items = this.mapOrderItems(order);
 
     return {
       id: order.id,
@@ -258,6 +262,8 @@ export class OrdersService {
   }
 
   private toCustomerOrderResponse(order: Order): CustomerOrderResponseDto {
+    const items = this.mapOrderItems(order);
+
     return {
       id: order.id,
       totalAmount: Number(order.totalAmount),
@@ -269,6 +275,7 @@ export class OrdersService {
       shippingStatus: order.shippingStatus,
       shippingUpdatedAt: order.shippingUpdatedAt,
       placedAt: order.placedAt,
+      items,
     };
   }
 }

--- a/frontend/src/api/customerOrders.ts
+++ b/frontend/src/api/customerOrders.ts
@@ -1,5 +1,20 @@
 import { http } from './http';
 
+export interface CustomerOrderItemDto {
+  id: number;
+  product: {
+    id: number;
+    title: string;
+    sku: string;
+  };
+  size: {
+    id: number;
+    size: string;
+  } | null;
+  quantity: number;
+  unitPrice: number;
+}
+
 export interface CustomerOrderDto {
   id: number;
   totalAmount: number;
@@ -11,6 +26,7 @@ export interface CustomerOrderDto {
   shippingStatus: string;
   shippingUpdatedAt: string;
   placedAt: string;
+  items: CustomerOrderItemDto[];
 }
 
 export const fetchCustomerOrders = async (): Promise<CustomerOrderDto[]> => {

--- a/frontend/src/pages/OrdersHistoryPage.vue
+++ b/frontend/src/pages/OrdersHistoryPage.vue
@@ -21,29 +21,71 @@
         <div v-else-if="!orders.length" class="alert alert-info" role="alert">
           Заказов пока нет. Добавьте товары в корзину и оформите заказ.
         </div>
-        <div v-else class="table-responsive">
-          <table class="table align-middle mb-0">
-            <thead>
-              <tr>
-                <th scope="col">№ заказа</th>
-                <th scope="col">Дата оформления</th>
-                <th scope="col">Сумма</th>
-                <th scope="col">Статус оплаты</th>
-                <th scope="col">Статус отправки</th>
-                <th scope="col">Обновлено</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="order in orders" :key="order.id">
-                <th scope="row">{{ order.id }}</th>
-                <td>{{ formatDate(order.placedAt) }}</td>
-                <td>{{ formatCurrency(order.totalAmount) }}</td>
-                <td><span class="status-chip">{{ order.status.name }}</span></td>
-                <td>{{ order.shippingStatus }}</td>
-                <td>{{ formatDate(order.shippingUpdatedAt) }}</td>
-              </tr>
-            </tbody>
-          </table>
+        <div v-else class="orders-list">
+          <article v-for="order in orders" :key="order.id" class="order-card">
+            <header class="order-card__header">
+              <div>
+                <span class="order-card__number">Заказ №{{ order.id }}</span>
+                <p class="order-card__date">Оформлен {{ formatDate(order.placedAt) }}</p>
+              </div>
+              <div class="order-card__chips">
+                <span class="status-chip">{{ order.status.name }}</span>
+                <span class="order-card__chip-muted">{{ order.shippingStatus }}</span>
+              </div>
+            </header>
+
+            <div class="order-card__summary">
+              <div class="summary-item">
+                <span class="summary-item__label">Оплата</span>
+                <span class="summary-item__value">{{ order.paymentMethod ?? 'Не указано' }}</span>
+              </div>
+              <div class="summary-item">
+                <span class="summary-item__label">Товары</span>
+                <span class="summary-item__value">
+                  {{ getTotalQuantity(order) }} шт · {{ formatCurrency(order.totalAmount) }}
+                </span>
+              </div>
+              <div class="summary-item">
+                <span class="summary-item__label">Обновлено</span>
+                <span class="summary-item__value">{{ formatDate(order.shippingUpdatedAt) }}</span>
+              </div>
+            </div>
+
+            <div class="order-card__actions">
+              <button
+                class="btn btn-outline-secondary btn-sm"
+                type="button"
+                @click="toggleOrder(order.id)"
+                :aria-expanded="isExpanded(order.id)"
+              >
+                {{ isExpanded(order.id) ? 'Скрыть состав заказа' : 'Показать состав заказа' }}
+              </button>
+            </div>
+
+            <transition name="fade">
+              <div v-if="isExpanded(order.id)" class="order-card__items">
+                <div v-if="!order.items.length" class="alert alert-warning mb-0" role="alert">
+                  Состав заказа недоступен.
+                </div>
+                <ul v-else class="order-items">
+                  <li v-for="item in order.items" :key="item.id" class="order-item">
+                    <div>
+                      <p class="order-item__title">{{ item.product.title }}</p>
+                      <p class="order-item__meta">
+                        Артикул: {{ item.product.sku }}
+                        <span v-if="item.size" class="order-item__size">· Размер: {{ item.size.size }}</span>
+                      </p>
+                    </div>
+                    <div class="order-item__pricing">
+                      <span class="order-item__price">{{ formatCurrency(item.unitPrice) }}</span>
+                      <span class="order-item__quantity">× {{ item.quantity }}</span>
+                      <span class="order-item__subtotal">{{ formatCurrency(getItemSubtotal(item)) }}</span>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </transition>
+          </article>
         </div>
       </div>
     </div>
@@ -53,12 +95,17 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
-import { fetchCustomerOrders, type CustomerOrderDto } from '../api/customerOrders';
+import {
+  fetchCustomerOrders,
+  type CustomerOrderDto,
+  type CustomerOrderItemDto,
+} from '../api/customerOrders';
 import { extractErrorMessage } from '../api/http';
 
 const orders = ref<CustomerOrderDto[]>([]);
 const loading = ref(false);
 const errorMessage = ref<string | null>(null);
+const expandedOrderIds = ref<number[]>([]);
 
 const formatCurrency = (value: number) => `${value.toLocaleString('ru-RU')} ₽`;
 
@@ -67,11 +114,28 @@ const formatDate = (value: string) => {
   return date.toLocaleString('ru-RU');
 };
 
+const isExpanded = (orderId: number) => expandedOrderIds.value.includes(orderId);
+
+const toggleOrder = (orderId: number) => {
+  if (isExpanded(orderId)) {
+    expandedOrderIds.value = expandedOrderIds.value.filter((id) => id !== orderId);
+  } else {
+    expandedOrderIds.value = [...expandedOrderIds.value, orderId];
+  }
+};
+
+const getTotalQuantity = (order: CustomerOrderDto) =>
+  order.items.reduce((sum, item) => sum + item.quantity, 0);
+
+const getItemSubtotal = (item: CustomerOrderItemDto) => item.unitPrice * item.quantity;
+
 const loadOrders = async () => {
   try {
     loading.value = true;
     errorMessage.value = null;
-    orders.value = await fetchCustomerOrders();
+    const response = await fetchCustomerOrders();
+    orders.value = response;
+    expandedOrderIds.value = response.length ? [response[0].id] : [];
   } catch (error) {
     errorMessage.value = extractErrorMessage(error);
   } finally {
@@ -94,6 +158,70 @@ onMounted(() => {
   margin-bottom: 2.5rem;
 }
 
+.orders-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.order-card {
+  position: relative;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-surface-border);
+  background: linear-gradient(
+      130deg,
+      color-mix(in srgb, var(--color-surface) 92%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt) 88%, transparent) 100%
+    ),
+    color-mix(in srgb, var(--color-surface) 88%, transparent);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(calc(var(--blur-radius) * 0.9));
+  overflow: hidden;
+}
+
+.order-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(120% 140% at 0% 0%, color-mix(in srgb, var(--color-accent) 24%, transparent) 0%, transparent 55%),
+    radial-gradient(120% 150% at 110% 10%, color-mix(in srgb, var(--color-glow) 30%, transparent) 0%, transparent 60%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.order-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.order-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  align-items: flex-start;
+}
+
+.order-card__number {
+  display: block;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.order-card__date {
+  margin-bottom: 0;
+  color: var(--color-text-muted);
+}
+
+.order-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
 .status-chip {
   display: inline-flex;
   align-items: center;
@@ -106,9 +234,127 @@ onMounted(() => {
   text-transform: uppercase;
 }
 
+.order-card__chip-muted {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border) 80%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 70%, transparent);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.order-card__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem 1.5rem;
+  margin-top: 1.25rem;
+}
+
+.summary-item__label {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.summary-item__value {
+  font-weight: 600;
+  margin-top: 0.35rem;
+}
+
+.order-card__actions {
+  margin-top: 1.25rem;
+}
+
+.order-card__items {
+  margin-top: 1.5rem;
+}
+
+.order-items {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-item {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border) 75%, transparent);
+  background: color-mix(in srgb, var(--color-surface-alt) 85%, transparent);
+  box-shadow: 0 18px 28px -32px rgba(10, 12, 25, 0.85);
+}
+
+.order-item__title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.order-item__meta {
+  margin-bottom: 0;
+  color: var(--color-text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.order-item__size {
+  color: color-mix(in srgb, var(--color-text) 70%, var(--color-accent) 30%);
+}
+
+.order-item__pricing {
+  display: grid;
+  text-align: right;
+  gap: 0.25rem;
+  min-width: 140px;
+}
+
+.order-item__price {
+  font-weight: 600;
+}
+
+.order-item__quantity {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.order-item__subtotal {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
 @media (max-width: 575.98px) {
   .orders-header :deep(.btn) {
     width: 100%;
+  }
+
+  .order-card {
+    padding: 1.25rem;
+  }
+
+  .order-item__pricing {
+    justify-items: flex-start;
+    text-align: left;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- restyle the order history cards to use the app's glassmorphism surfaces and accent glow that adapts to light and dark themes
- adjust supporting chip, metadata, and line item colors to rely on shared text and surface variables
- add subtle overlay and shadow treatments so expanded items feel consistent with the rest of the storefront visuals

## Testing
- `npm run build` (backend)
- `npm run build` (frontend)`

------
https://chatgpt.com/codex/tasks/task_e_68f7042490148321b005df5ab6509316