### PR TITLE
feat: allow customers to cancel orders

### DIFF
--- a/backend/src/modules/orders/customer-orders.controller.ts
+++ b/backend/src/modules/orders/customer-orders.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -33,5 +41,15 @@ export class CustomerOrdersController {
     @Req() req: AuthenticatedRequest,
   ): Promise<CustomerOrderResponseDto[]> {
     return this.ordersService.findForUser(req.user.id);
+  }
+
+  @Patch(':id/cancel')
+  @ApiOperation({ summary: 'Отменить заказ текущего пользователя' })
+  @ApiOkResponse({ description: 'Заказ отменён', type: CustomerOrderResponseDto })
+  cancelMyOrder(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CustomerOrderResponseDto> {
+    return this.ordersService.cancelForUser(id, req.user.id);
   }
 }

--- a/backend/src/modules/orders/orders.constants.ts
+++ b/backend/src/modules/orders/orders.constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_SHIPPING_STATUS = 'Готовится к отправке';
+export const CANCELLED_STATUS_NAME = 'Отменен';
+export const CANCELLED_SHIPPING_STATUS = 'Отменен пользователем';

--- a/frontend/src/api/customerOrders.ts
+++ b/frontend/src/api/customerOrders.ts
@@ -33,3 +33,12 @@ export const fetchCustomerOrders = async (): Promise<CustomerOrderDto[]> => {
   const { data } = await http.get<CustomerOrderDto[]>('/customer/orders');
   return data;
 };
+
+export const cancelCustomerOrder = async (
+  orderId: number,
+): Promise<CustomerOrderDto> => {
+  const { data } = await http.patch<CustomerOrderDto>(
+    `/customer/orders/${orderId}/cancel`,
+  );
+  return data;
+};


### PR DESCRIPTION
## Summary
- expose a PATCH endpoint under `customer/orders/:id/cancel` with service logic that locks orders to the "Готовится к отправке" shipping state and applies the cancelled status
- wire the frontend API and orders history view to invoke the cancellation, showing a button with proper loading feedback when an order is eligible
- tweak the history card layout so action buttons align when the cancel control is present

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68f744f5760483218801b79f769bd7d4