### PR TITLE
fix: ensure jwt guard exposes normalized user id

### DIFF
--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -20,8 +20,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Недействительный токен');
     }
 
+    const userId = payload.sub;
+
     return {
-      userId: payload.sub,
+      id: userId,
+      userId,
       email: payload.email,
       role: payload.role,
     };


### PR DESCRIPTION
## Summary
- populate both id and userId fields in the JWT strategy validation result so customer endpoints can reliably resolve the authenticated user

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5173
- curl http://127.0.0.1:3000/customer/orders -H "Authorization: Bearer $USER1_TOKEN"
- curl http://127.0.0.1:3000/customer/orders -H "Authorization: Bearer $USER2_TOKEN"

------
https://chatgpt.com/codex/tasks/task_e_68f76c25ff548321909d048159baa8a1