### PR TITLE
feat: align modal dialogs with theme tokens

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@headlessui/vue": "^1.7.17",
+        "@heroicons/vue": "^2.1.5",
         "apexcharts": "^5.3.5",
         "axios": "^1.12.2",
         "bootstrap": "^5.3.8",
@@ -513,6 +515,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@headlessui/vue": {
+      "version": "1.7.17",
+      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.17.tgz",
+      "integrity": "sha512-hmJChv8HzKorxd9F70RGnECAwZfkvmmwOqreuKLWY/19d5qbWnSdw+DNbuA/Uo6X5rb4U5B3NrT+qBKPmjhRqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/vue-virtual": "^3.0.0-beta.60"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@heroicons/vue": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.1.5.tgz",
+      "integrity": "sha512-IpqR72sFqFs55kyKfFS7tN+Ww6odFNeH/7UxycIOrlVYfj4WUGAdzQtLBnJspucSeqWFQsKM0g0YrgU655BEfA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": ">= 3"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -905,6 +931,32 @@
       },
       "peerDependencies": {
         "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.12.tgz",
+      "integrity": "sha512-vhF7kEU9EXWXh+HdAwKJ2m3xaOnTTmgcdXcF2pim8g4GvI7eRrk2YRuV5nUlZnd/NbCIX4/Ja2OZu5EjJL06Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
       }
     },
     "node_modules/@types/estree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@headlessui/vue": "^1.7.17",
+    "@heroicons/vue": "^2.1.5",
     "apexcharts": "^5.3.5",
     "axios": "^1.12.2",
     "bootstrap": "^5.3.8",

--- a/frontend/src/components/LogoutConfirmModal.vue
+++ b/frontend/src/components/LogoutConfirmModal.vue
@@ -1,37 +1,58 @@
 <template>
   <Teleport to="body">
-    <transition name="fade">
-      <div v-if="visible" class="modal-backdrop fade show"></div>
-    </transition>
-    <transition name="scale">
-      <div
-        v-if="visible"
-        class="modal glass-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="logout-modal-title"
-        @click.self="emitCancel"
-      >
-        <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content p-4">
-            <div class="modal-body text-center p-0">
-              <p id="logout-modal-title" class="fs-5 mb-4 fw-semibold">
-                Вы действительно хотите выйти из аккаунта?
-              </p>
-              <div class="d-flex justify-content-center gap-3 flex-wrap">
-                <button type="button" class="btn btn-danger" @click="emitConfirm">Да</button>
-                <button type="button" class="btn btn-outline-secondary" @click="emitCancel">Отмена</button>
+    <TransitionRoot :show="visible" appear as="template">
+      <Dialog as="div" class="modal-layer" @close="emitCancel">
+        <TransitionChild
+          as="template"
+          enter="modal-fade-enter"
+          enter-from="modal-fade-enter-from"
+          enter-to="modal-fade-enter-to"
+          leave="modal-fade-leave"
+          leave-from="modal-fade-leave-from"
+          leave-to="modal-fade-leave-to"
+        >
+          <div class="modal-layer__backdrop" aria-hidden="true"></div>
+        </TransitionChild>
+        <div class="modal-layer__container">
+          <TransitionChild
+            as="template"
+            enter="modal-panel-enter"
+            enter-from="modal-panel-enter-from"
+            enter-to="modal-panel-enter-to"
+            leave="modal-panel-leave"
+            leave-from="modal-panel-leave-from"
+            leave-to="modal-panel-leave-to"
+          >
+            <DialogPanel class="confirm-dialog" aria-describedby="logout-modal-description">
+              <div class="confirm-dialog__icon" aria-hidden="true">
+                <ArrowRightStartOnRectangleIcon />
               </div>
-            </div>
-          </div>
+              <DialogTitle id="logout-modal-title" as="h2" class="confirm-dialog__title">
+                Выйти из аккаунта?
+              </DialogTitle>
+              <p id="logout-modal-description" class="confirm-dialog__subtitle">
+                Вы сможете снова войти в любой момент. Все незавершённые действия будут отменены.
+              </p>
+              <div class="confirm-dialog__actions">
+                <button type="button" class="confirm-dialog__action confirm-dialog__action--danger" @click="emitConfirm">
+                  Выйти
+                </button>
+                <button type="button" class="confirm-dialog__action" @click="emitCancel">
+                  Остаться
+                </button>
+              </div>
+            </DialogPanel>
+          </TransitionChild>
         </div>
-      </div>
-    </transition>
+      </Dialog>
+    </TransitionRoot>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, watch } from 'vue';
+import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { ArrowRightStartOnRectangleIcon } from '@heroicons/vue/24/outline';
+import { computed } from 'vue';
 import { useScrollLock } from '../composables/useScrollLock';
 
 const props = defineProps<{ visible: boolean }>();
@@ -42,29 +63,7 @@ const emit = defineEmits<{
 
 const visible = computed(() => props.visible);
 
-const handleKeyup = (event: KeyboardEvent) => {
-  if (event.key === 'Escape' && visible.value) {
-    emit('cancel');
-  }
-};
-
 useScrollLock(visible);
-
-watch(
-  visible,
-  (value) => {
-    if (value) {
-      window.addEventListener('keyup', handleKeyup);
-    } else {
-      window.removeEventListener('keyup', handleKeyup);
-    }
-  },
-  { immediate: true },
-);
-
-onBeforeUnmount(() => {
-  window.removeEventListener('keyup', handleKeyup);
-});
 
 const emitConfirm = () => {
   emit('confirm');
@@ -76,25 +75,192 @@ const emitCancel = () => {
 </script>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.28s ease;
+.modal-fade-enter,
+.modal-fade-leave {
+  transition: opacity 0.24s ease;
 }
 
-.fade-enter-from,
-.fade-leave-to {
+.modal-fade-enter-from,
+.modal-fade-leave-to {
   opacity: 0;
 }
 
-.scale-enter-active,
-.scale-leave-active {
-  transition: transform 0.3s ease, opacity 0.3s ease;
+.modal-fade-enter-to,
+.modal-fade-leave-from {
+  opacity: 1;
 }
 
-.scale-enter-from,
-.scale-leave-to {
+.modal-panel-enter,
+.modal-panel-leave {
+  transition: transform 0.28s ease, opacity 0.28s ease;
+}
+
+.modal-panel-enter-from,
+.modal-panel-leave-to {
+  opacity: 0;
   transform: translateY(18px) scale(0.95);
-  opacity: 0;
 }
 
+.modal-panel-enter-to,
+.modal-panel-leave-from {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.modal-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+}
+
+.modal-layer__backdrop {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(120% 130% at 20% 10%, color-mix(in srgb, var(--color-accent) 22%, transparent) 0%, transparent 70%),
+    radial-gradient(140% 160% at 80% 0%, color-mix(in srgb, var(--color-accent-strong) 16%, transparent) 0%, transparent 72%),
+    color-mix(in srgb, var(--color-background) 88%, rgba(6, 6, 8, 0.82));
+  backdrop-filter: blur(calc(var(--blur-radius, 12px) * 1.2));
+}
+
+.modal-layer__container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: clamp(18px, 5vw, 44px);
+  overflow-y: auto;
+}
+
+.confirm-dialog {
+  width: min(420px, 100%);
+  padding: clamp(24px, 5vw, 32px);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--color-surface-strong, rgba(18, 18, 22, 0.95)) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 70%, transparent);
+  box-shadow:
+    0 35px 80px -55px rgba(0, 0, 0, 0.75),
+    0 0 0 1px color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 40%, transparent) inset,
+    0 18px 45px -32px color-mix(in srgb, var(--color-accent) 26%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  isolation: isolate;
+}
+
+.confirm-dialog__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 66px;
+  height: 66px;
+  border-radius: 22px;
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-accent) 35%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong, var(--color-accent)) 18%, transparent) 100%),
+    linear-gradient(140deg, color-mix(in srgb, var(--color-surface) 75%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt, rgba(20, 20, 20, 0.82)) 60%, transparent) 100%);
+  color: color-mix(in srgb, var(--color-text, rgba(255, 255, 255, 0.9)) 96%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.1)) 85%, transparent);
+}
+
+.confirm-dialog__icon svg {
+  width: 32px;
+  height: 32px;
+}
+
+.confirm-dialog__title {
+  margin: 0;
+  font-size: clamp(1.3rem, 1.1rem + 0.5vw, 1.5rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: color-mix(in srgb, var(--color-text, rgba(255, 255, 255, 0.94)) 96%, transparent);
+}
+
+.confirm-dialog__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: color-mix(in srgb, var(--color-text-muted, rgba(235, 235, 245, 0.7)) 95%, transparent);
+}
+
+.confirm-dialog__actions {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.confirm-dialog__action {
+  width: 100%;
+  padding: 0.85rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.16)) 70%, transparent);
+  background: color-mix(in srgb, var(--color-surface, rgba(255, 255, 255, 0.04)) 70%, transparent);
+  color: color-mix(in srgb, var(--color-text, rgba(255, 255, 255, 0.92)) 96%, transparent);
+  font-weight: 600;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.confirm-dialog__action:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.28)) 85%, transparent);
+  background: color-mix(in srgb, var(--color-surface, rgba(255, 255, 255, 0.1)) 80%, transparent);
+}
+
+.confirm-dialog__action--danger {
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-accent) 82%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong, var(--color-accent)) 60%, transparent) 100%),
+    color-mix(in srgb, var(--color-surface, rgba(255, 255, 255, 0.04)) 40%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 80%, transparent);
+  color: #ffffff;
+  box-shadow: 0 18px 40px -28px color-mix(in srgb, var(--color-accent) 90%, transparent);
+}
+
+.confirm-dialog__action--danger:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--color-accent) 92%, transparent);
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-accent) 94%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong, var(--color-accent)) 78%, transparent) 100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-fade-enter,
+  .modal-fade-leave,
+  .modal-panel-enter,
+  .modal-panel-leave,
+  .confirm-dialog__action {
+    transition-duration: 0.01ms;
+    transition-delay: 0.01ms;
+  }
+}
+
+@media (min-width: 520px) {
+  .confirm-dialog__actions {
+    flex-direction: row;
+  }
+
+  .confirm-dialog__action {
+    flex: 1;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .modal-layer__container {
+    padding: clamp(16px, 6vw, 26px) clamp(16px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
+    align-items: flex-end;
+  }
+
+  .confirm-dialog {
+    border-radius: 22px;
+    gap: 1.1rem;
+  }
+}
 </style>

--- a/frontend/src/components/ProductSizeModal.vue
+++ b/frontend/src/components/ProductSizeModal.vue
@@ -1,65 +1,82 @@
 <template>
   <Teleport to="body">
-    <transition name="fade">
-      <div v-if="visible" class="modal-backdrop fade show"></div>
-    </transition>
-    <transition name="scale">
-      <div
-        v-if="visible"
-        class="modal glass-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="size-modal-title"
-        @click.self="emitClose"
-      >
-        <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-            <header class="modal-header border-0 pb-0">
-              <h2 id="size-modal-title" class="modal-title h4 mb-0">
-                Выберите размер
-              </h2>
-              <button type="button" class="btn-close" aria-label="Закрыть" @click="emitClose"></button>
-            </header>
-            <section class="modal-body">
-              <p v-if="product" class="text-muted mb-3">
-                Товар «{{ product.title }}» доступен в нескольких размерах. Выберите подходящий, чтобы добавить его в корзину.
-              </p>
-              <p v-else class="text-muted mb-3">
-                Выберите размер товара, чтобы продолжить оформление.
-              </p>
-              <div v-if="availableSizes.length" class="size-options" role="group" aria-label="Выбор размера">
-                <button
-                  v-for="size in availableSizes"
-                  :key="size.id"
-                  type="button"
-                  class="size-options__item"
-                  :class="{ 'size-options__item--disabled': size.stock <= 0 }"
-                  :disabled="size.stock <= 0 || disabled"
-                  @click="handleSelect(size.id)"
-                >
-                  <span class="size-options__label">{{ size.size }}</span>
-                  <span class="size-options__price">{{ formatCurrency(size.price) }}</span>
-                  <small class="size-options__stock">{{ stockLabel(size.stock) }}</small>
+    <TransitionRoot :show="visible" appear as="template">
+      <Dialog as="div" class="modal-layer" @close="handleDialogClose">
+        <TransitionChild
+          as="template"
+          enter="modal-fade-enter"
+          enter-from="modal-fade-enter-from"
+          enter-to="modal-fade-enter-to"
+          leave="modal-fade-leave"
+          leave-from="modal-fade-leave-from"
+          leave-to="modal-fade-leave-to"
+        >
+          <div class="modal-layer__backdrop" aria-hidden="true"></div>
+        </TransitionChild>
+        <div class="modal-layer__container">
+          <TransitionChild
+            as="template"
+            enter="modal-panel-enter"
+            enter-from="modal-panel-enter-from"
+            enter-to="modal-panel-enter-to"
+            leave="modal-panel-leave"
+            leave-from="modal-panel-leave-from"
+            leave-to="modal-panel-leave-to"
+          >
+            <DialogPanel class="size-dialog">
+              <header class="size-dialog__header">
+                <div class="size-dialog__title-wrap">
+                  <DialogTitle id="size-modal-title" as="h2" class="size-dialog__title">
+                    Выберите размер
+                  </DialogTitle>
+                  <p v-if="product" class="size-dialog__subtitle">
+                    Товар «{{ product.title }}» доступен в нескольких размерах. Выберите подходящий, чтобы добавить его в корзину.
+                  </p>
+                  <p v-else class="size-dialog__subtitle">
+                    Выберите размер товара, чтобы продолжить оформление.
+                  </p>
+                </div>
+                <button type="button" class="size-dialog__close" aria-label="Закрыть" @click="emitClose">
+                  <XMarkIcon aria-hidden="true" />
                 </button>
-              </div>
-              <p v-else class="alert alert-warning mb-0">
-                Для этого товара временно нет доступных размеров.
-              </p>
-            </section>
-            <footer class="modal-footer border-0 pt-0">
-              <button type="button" class="btn btn-outline-secondary" @click="emitClose" :disabled="disabled">
-                Отмена
-              </button>
-            </footer>
-          </div>
+              </header>
+              <section class="size-dialog__body" :aria-labelledby="product ? 'size-modal-title' : undefined">
+                <div v-if="availableSizes.length" class="size-options" role="group" aria-label="Выбор размера">
+                  <button
+                    v-for="size in availableSizes"
+                    :key="size.id"
+                    type="button"
+                    class="size-options__item"
+                    :class="{ 'size-options__item--disabled': size.stock <= 0, 'size-options__item--blocked': disabled }"
+                    :disabled="size.stock <= 0 || disabled"
+                    @click="handleSelect(size.id)"
+                  >
+                    <span class="size-options__label">{{ size.size }}</span>
+                    <span class="size-options__price">{{ formatCurrency(size.price) }}</span>
+                    <small class="size-options__stock">{{ stockLabel(size.stock) }}</small>
+                  </button>
+                </div>
+                <div v-else class="size-dialog__empty" role="status">
+                  <p>Для этого товара временно нет доступных размеров.</p>
+                </div>
+              </section>
+              <footer class="size-dialog__footer">
+                <button type="button" class="size-dialog__cancel" @click="emitClose" :disabled="disabled">
+                  Отмена
+                </button>
+              </footer>
+            </DialogPanel>
+          </TransitionChild>
         </div>
-      </div>
-    </transition>
+      </Dialog>
+    </TransitionRoot>
   </Teleport>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, watch } from 'vue';
+import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { XMarkIcon } from '@heroicons/vue/24/outline';
+import { computed } from 'vue';
 import type { ProductDto, ProductSizeDto } from '../api/products';
 import { useScrollLock } from '../composables/useScrollLock';
 
@@ -106,116 +123,313 @@ const emitClose = () => {
   emit('close');
 };
 
-const handleKeyup = (event: KeyboardEvent) => {
-  if (event.key === 'Escape' && visible.value) {
-    emitClose();
-  }
-};
-
 useScrollLock(visible);
 
-watch(
-  visible,
-  (value) => {
-    if (value) {
-      window.addEventListener('keyup', handleKeyup);
-      return;
-    }
-    window.removeEventListener('keyup', handleKeyup);
-  },
-  { immediate: true },
-);
-
-onBeforeUnmount(() => {
-  window.removeEventListener('keyup', handleKeyup);
-});
+const handleDialogClose = () => {
+  if (disabled.value) {
+    return;
+  }
+  emitClose();
+};
 </script>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.28s ease;
+.modal-fade-enter,
+.modal-fade-leave {
+  transition: opacity 0.24s ease;
 }
 
-.fade-enter-from,
-.fade-leave-to {
+.modal-fade-enter-from,
+.modal-fade-leave-to {
   opacity: 0;
 }
 
-.scale-enter-active,
-.scale-leave-active {
-  transition: transform 0.3s ease, opacity 0.3s ease;
+.modal-fade-enter-to,
+.modal-fade-leave-from {
+  opacity: 1;
 }
 
-.scale-enter-from,
-.scale-leave-to {
-  transform: translateY(18px) scale(0.95);
+.modal-panel-enter,
+.modal-panel-leave {
+  transition: transform 0.28s ease, opacity 0.28s ease;
+}
+
+.modal-panel-enter-from,
+.modal-panel-leave-to {
   opacity: 0;
+  transform: translateY(22px) scale(0.95);
+}
+
+.modal-panel-enter-to,
+.modal-panel-leave-from {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.modal-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+}
+
+.modal-layer__backdrop {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(115% 125% at 22% 18%, color-mix(in srgb, var(--color-accent) 28%, transparent) 0%, transparent 68%),
+    radial-gradient(110% 135% at 78% 16%, color-mix(in srgb, var(--color-accent-strong) 18%, transparent) 0%, transparent 72%),
+    color-mix(in srgb, var(--color-background) 86%, rgba(6, 6, 8, 0.82));
+  backdrop-filter: blur(calc(var(--blur-radius, 12px) * 1.4));
+}
+
+.modal-layer__container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 5vw, 48px) clamp(16px, 4vw, 36px);
+  overflow-y: auto;
+}
+
+.size-dialog {
+  position: relative;
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(24px, 4vw, 32px);
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--color-surface-strong, rgba(18, 18, 22, 0.96)) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 70%, transparent);
+  box-shadow:
+    0 45px 100px -55px rgba(0, 0, 0, 0.7),
+    0 0 0 1px color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 35%, transparent) inset,
+    0 24px 60px -40px color-mix(in srgb, var(--color-accent) 26%, transparent);
+  backdrop-filter: blur(calc(var(--blur-radius, 12px) * 1.2));
+  max-height: min(90vh, 640px);
+  overflow: hidden;
+}
+
+.size-dialog__header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.size-dialog__title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.size-dialog__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.1rem + 0.8vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: #f8f8fa;
+}
+
+.size-dialog__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(235, 235, 245, 0.72);
+  line-height: 1.6;
+}
+
+.size-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  color: rgba(250, 250, 255, 0.82);
+  transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+
+.size-dialog__close svg {
+  width: 22px;
+  height: 22px;
+}
+
+.size-dialog__close:hover {
+  transform: translateY(-1px) scale(1.02);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: #ffffff;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.04));
+}
+
+.size-dialog__close:focus-visible {
+  outline: 2px solid rgba(255, 77, 109, 0.65);
+  outline-offset: 3px;
+}
+
+.size-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  padding-right: clamp(2px, 0.5vw, 8px);
 }
 
 .size-options {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .size-options__item {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  gap: 0.35rem;
   align-items: flex-start;
-  gap: 0.25rem;
-  padding: 0.85rem 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.06);
-  color: #ffffff;
-  transition: border-color 0.2s ease, transform 0.2s ease, background-color 0.2s ease,
-    color 0.2s ease;
+  justify-items: flex-start;
+  padding: 1rem 1.15rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.12)) 65%, transparent);
+  background: linear-gradient(145deg, color-mix(in srgb, var(--color-surface) 82%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt, rgba(20, 20, 20, 0.82)) 65%, transparent) 100%);
+  color: color-mix(in srgb, var(--color-text, #f8f8fa) 92%, transparent);
+  cursor: pointer;
+  transition: transform 0.22s ease, border-color 0.22s ease, background 0.22s ease, box-shadow 0.22s ease;
   width: 100%;
 }
 
 .size-options__item:hover:not(:disabled) {
-  border-color: rgba(147, 175, 255, 0.65);
-  transform: translateY(-1px);
-  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--color-accent) 16%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong, var(--color-accent)) 12%, transparent) 100%),
+    linear-gradient(145deg, color-mix(in srgb, var(--color-surface) 80%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt, rgba(20, 20, 20, 0.82)) 60%, transparent) 100%);
+  box-shadow: 0 18px 45px -32px color-mix(in srgb, var(--color-accent) 70%, transparent);
+}
+
+.size-options__item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--color-outline, rgba(255, 77, 109, 0.6)) 95%, transparent);
+  outline-offset: 3px;
 }
 
 .size-options__item:disabled,
 .size-options__item--disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.5;
+  transform: none;
+}
+
+.size-options__item--blocked {
+  cursor: progress;
+  opacity: 0.65;
 }
 
 .size-options__label {
   font-weight: 600;
-  font-size: 1rem;
-  color: #ffffff;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+  color: color-mix(in srgb, var(--color-text, #ffffff) 95%, transparent);
 }
 
 .size-options__price {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.82);
+  color: color-mix(in srgb, var(--color-text-muted, rgba(255, 255, 255, 0.78)) 100%, transparent);
 }
 
 .size-options__stock {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: color-mix(in srgb, var(--color-text-muted, rgba(255, 255, 255, 0.6)) 90%, transparent);
+}
+
+.size-dialog__empty {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px dashed color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.24)) 75%, transparent);
+  background: color-mix(in srgb, var(--color-surface, rgba(255, 255, 255, 0.05)) 65%, transparent);
+  text-align: center;
+  color: color-mix(in srgb, var(--color-text-muted, rgba(255, 255, 255, 0.72)) 100%, transparent);
+}
+
+.size-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.size-dialog__cancel {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.18)) 65%, transparent);
+  background: color-mix(in srgb, var(--color-surface, rgba(255, 255, 255, 0.05)) 60%, transparent);
+  color: color-mix(in srgb, var(--color-text, rgba(255, 255, 255, 0.86)) 96%, transparent);
+  font-weight: 600;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.size-dialog__cancel:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  color: #ffffff;
+}
+
+.size-dialog__cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-fade-enter,
+  .modal-fade-leave,
+  .modal-panel-enter,
+  .modal-panel-leave,
+  .size-options__item,
+  .size-dialog__cancel {
+    transition-duration: 0.01ms;
+    transition-delay: 0.01ms;
+  }
 }
 
 @media (max-width: 575.98px) {
+  .modal-layer__container {
+    padding: clamp(16px, 6vw, 28px) clamp(14px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
+    align-items: flex-end;
+  }
+
+  .size-dialog {
+    padding: clamp(22px, 6vw, 28px);
+    border-radius: 20px;
+    gap: 1.25rem;
+    max-height: min(88vh, 560px);
+  }
+
+  .size-dialog__header {
+    gap: 0.75rem;
+  }
+
+  .size-dialog__close {
+    width: 36px;
+    height: 36px;
+  }
+
   .size-options {
-    gap: 0.65rem;
+    gap: 0.75rem;
+    grid-template-columns: 1fr;
   }
 
   .size-options__item {
-    padding: 0.75rem 0.85rem;
+    padding: 0.85rem 1rem;
   }
 
-  .size-options__label {
-    font-size: 0.95rem;
+  .size-dialog__footer {
+    justify-content: stretch;
   }
 
-  .size-options__price {
-    font-size: 0.9rem;
+  .size-dialog__cancel {
+    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- restyle the product size selector modal around design tokens, responsive layout limits, and aria labelling
- refresh the logout confirmation modal with theme-aware surfaces and improved accessibility affordances
- verify the flows end-to-end against the running backend/frontend dev servers after installing dependencies and seeding data

## Testing
- npm run build (backend)
- npm run build (frontend)
- npm run start:dev (backend)
- npm run dev -- --host 0.0.0.0 --port 5173 (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68f80464b2e48321a64e14e95993b5c7