### PR TITLE
fix: center modal overlays on small viewports

### DIFF
--- a/frontend/src/components/LogoutConfirmModal.vue
+++ b/frontend/src/components/LogoutConfirmModal.vue
@@ -107,7 +107,7 @@ const emitCancel = () => {
   transform: translateY(0) scale(1);
 }
 
-.modal-layer {
+:global(.modal-layer) {
   position: fixed;
   inset: 0;
   z-index: 1050;
@@ -254,8 +254,8 @@ const emitCancel = () => {
 
 @media (max-width: 575.98px) {
   .modal-layer__container {
-    padding: clamp(16px, 6vw, 26px) clamp(16px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
-    align-items: flex-end;
+    padding: clamp(18px, 6vw, 28px) clamp(16px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
+    align-items: center;
   }
 
   .confirm-dialog {

--- a/frontend/src/components/ProductSizeModal.vue
+++ b/frontend/src/components/ProductSizeModal.vue
@@ -166,7 +166,7 @@ const handleDialogClose = () => {
   transform: translateY(0) scale(1);
 }
 
-.modal-layer {
+:global(.modal-layer) {
   position: fixed;
   inset: 0;
   z-index: 1050;
@@ -395,12 +395,12 @@ const handleDialogClose = () => {
 
 @media (max-width: 575.98px) {
   .modal-layer__container {
-    padding: clamp(16px, 6vw, 28px) clamp(14px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
-    align-items: flex-end;
+    padding: clamp(18px, 6vw, 30px) clamp(14px, 5vw, 22px) calc(24px + env(safe-area-inset-bottom));
+    align-items: center;
   }
 
   .size-dialog {
-    padding: clamp(22px, 6vw, 28px);
+    padding: clamp(22px, 6vw, 30px);
     border-radius: 20px;
     gap: 1.25rem;
     max-height: min(88vh, 560px);


### PR DESCRIPTION
## Summary
- ensure teleported modals keep fixed positioning by scoping the `.modal-layer` styles globally
- adjust mobile padding and alignment so size and logout dialogs remain centered on small screens

## Testing
- npm run build (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68f818c35eac8321b1c7a8b93eb2bf5b