### PR TITLE
Refactor storefront modals to the glass design

### DIFF
--- a/frontend/src/components/GlassModal.vue
+++ b/frontend/src/components/GlassModal.vue
@@ -1,0 +1,181 @@
+<template>
+  <Teleport to="body">
+    <TransitionRoot :show="visible" appear as="template">
+      <Dialog as="div" class="modal-layer" @close="handleClose">
+        <TransitionChild
+          as="template"
+          enter="modal-fade-enter"
+          enter-from="modal-fade-enter-from"
+          enter-to="modal-fade-enter-to"
+          leave="modal-fade-leave"
+          leave-from="modal-fade-leave-from"
+          leave-to="modal-fade-leave-to"
+        >
+          <div class="modal-layer__backdrop" aria-hidden="true"></div>
+        </TransitionChild>
+        <div class="modal-layer__container" :class="containerClass">
+          <TransitionChild
+            as="template"
+            enter="modal-panel-enter"
+            enter-from="modal-panel-enter-from"
+            enter-to="modal-panel-enter-to"
+            leave="modal-panel-leave"
+            leave-from="modal-panel-leave-from"
+            leave-to="modal-panel-leave-to"
+          >
+            <DialogPanel
+              class="glass-modal-panel"
+              :class="panelClass"
+              :style="{ maxWidth }"
+            >
+              <slot />
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </Dialog>
+    </TransitionRoot>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import {
+  Dialog,
+  DialogPanel,
+  TransitionChild,
+  TransitionRoot,
+} from '@headlessui/vue';
+import { computed, toRef } from 'vue';
+import { useScrollLock } from '../composables/useScrollLock';
+
+type ClassBinding = string | Record<string, boolean> | Array<string | Record<string, boolean>>;
+
+const props = withDefaults(
+  defineProps<{
+    visible: boolean;
+    panelClass?: ClassBinding;
+    containerClass?: ClassBinding;
+    maxWidth?: string;
+    preventClose?: boolean;
+  }>(),
+  {
+    panelClass: () => [],
+    containerClass: () => [],
+    maxWidth: '640px',
+    preventClose: false,
+  },
+);
+
+const emit = defineEmits<{ (event: 'close'): void }>();
+
+const visibleRef = toRef(props, 'visible');
+
+useScrollLock(visibleRef);
+
+const maxWidth = computed(() => props.maxWidth || '640px');
+
+const handleClose = () => {
+  if (props.preventClose) {
+    return;
+  }
+  emit('close');
+};
+</script>
+
+<style scoped>
+.modal-fade-enter,
+.modal-fade-leave {
+  transition: opacity 0.24s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-fade-enter-to,
+.modal-fade-leave-from {
+  opacity: 1;
+}
+
+.modal-panel-enter,
+.modal-panel-leave {
+  transition: transform 0.28s ease, opacity 0.28s ease;
+}
+
+.modal-panel-enter-from,
+.modal-panel-leave-to {
+  opacity: 0;
+  transform: translateY(22px) scale(0.95);
+}
+
+.modal-panel-enter-to,
+.modal-panel-leave-from {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+:global(.modal-layer) {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+}
+
+.modal-layer__backdrop {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(115% 125% at 22% 18%, color-mix(in srgb, var(--color-accent) 24%, transparent) 0%, transparent 70%),
+    radial-gradient(125% 145% at 78% 16%, color-mix(in srgb, var(--color-accent-strong) 18%, transparent) 0%, transparent 75%),
+    color-mix(in srgb, var(--color-background) 86%, rgba(6, 6, 8, 0.82));
+  backdrop-filter: blur(calc(var(--blur-radius, 12px) * 1.35));
+}
+
+.modal-layer__container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 5vw, 48px) clamp(16px, 4vw, 36px);
+  overflow-y: auto;
+}
+
+.glass-modal-panel {
+  width: min(100%, var(--modal-max-width, 640px));
+  max-width: 100%;
+  border-radius: clamp(20px, 4vw, 28px);
+  background: color-mix(in srgb, var(--color-surface-strong, rgba(12, 12, 12, 0.92)) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 65%, transparent);
+  box-shadow:
+    0 42px 90px -55px rgba(0, 0, 0, 0.78),
+    0 0 0 1px color-mix(in srgb, var(--color-surface-border, rgba(255, 255, 255, 0.08)) 45%, transparent) inset,
+    0 22px 55px -35px color-mix(in srgb, var(--color-accent) 24%, transparent);
+  padding: clamp(20px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  isolation: isolate;
+}
+
+:global([data-theme='light']) .glass-modal-panel {
+  background: color-mix(in srgb, var(--color-surface-strong, rgba(255, 255, 255, 0.96)) 96%, transparent);
+  box-shadow:
+    0 40px 90px -52px rgba(15, 23, 42, 0.28),
+    0 0 0 1px color-mix(in srgb, var(--color-surface-border, rgba(214, 214, 214, 0.7)) 55%, transparent) inset,
+    0 18px 48px -30px color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
+
+@media (max-width: 640px) {
+  .modal-layer__container {
+    padding: clamp(16px, 6vw, 28px) clamp(12px, 5vw, 20px);
+    align-items: flex-start;
+  }
+
+  .glass-modal-panel {
+    width: 100%;
+    border-radius: clamp(16px, 6vw, 22px);
+    padding: clamp(18px, 5vw, 24px);
+  }
+}
+</style>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -80,225 +80,250 @@
       </div>
     </section>
 
-    <Teleport to="body">
-      <div
-        v-if="createModalVisible"
-        class="modal fade show glass-modal"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="create-user-modal-title"
-        @click.self="closeCreateModal"
-      >
-        <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <form @submit.prevent="createUserAction">
-              <div class="modal-header">
-                <h2 id="create-user-modal-title" class="modal-title h5 mb-0">Новый пользователь</h2>
-                <button type="button" class="btn-close" aria-label="Закрыть" @click="closeCreateModal"></button>
-              </div>
-              <div class="modal-body">
-                <p class="modal-subtitle text-muted">
-                  Укажите контактные данные, роль и временный пароль для новой учетной записи.
-                </p>
-                <div class="modal-form-grid">
-                  <div class="modal-form-grid__item">
-                    <label for="createUserName" class="form-label">Имя</label>
-                    <input
-                      id="createUserName"
-                      v-model="createForm.name"
-                      type="text"
-                      class="form-control"
-                      placeholder="Имя и фамилия"
-                      required
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserEmail" class="form-label">Email</label>
-                    <input
-                      id="createUserEmail"
-                      v-model="createForm.email"
-                      type="email"
-                      class="form-control"
-                      placeholder="name@example.com"
-                      required
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserPhone" class="form-label">Телефон</label>
-                    <input
-                      id="createUserPhone"
-                      v-model="createForm.phone"
-                      type="tel"
-                      class="form-control"
-                      placeholder="Например, +7 900 000-00-00"
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserRole" class="form-label">Роль</label>
-                    <select
-                      id="createUserRole"
-                      v-model="createForm.roleName"
-                      class="form-select"
-                      required
-                      :disabled="creating"
-                    >
-                      <option value="">Выберите роль</option>
-                      <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.name }}</option>
-                    </select>
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserPassword" class="form-label">Пароль</label>
-                    <input
-                      id="createUserPassword"
-                      v-model="createForm.password"
-                      type="password"
-                      class="form-control"
-                      placeholder="Минимум 6 символов"
-                      required
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserCountry" class="form-label">Страна</label>
-                    <input
-                      id="createUserCountry"
-                      v-model="createForm.country"
-                      type="text"
-                      class="form-control"
-                      placeholder="Например, Россия"
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="createUserCity" class="form-label">Город</label>
-                    <input
-                      id="createUserCity"
-                      v-model="createForm.city"
-                      type="text"
-                      class="form-control"
-                      placeholder="Например, Москва"
-                      :disabled="creating"
-                    />
-                  </div>
-                  <div class="modal-form-grid__item modal-form-grid__item--full">
-                    <label for="createUserAddress" class="form-label">Адрес</label>
-                    <input
-                      id="createUserAddress"
-                      v-model="createForm.address"
-                      type="text"
-                      class="form-control"
-                      placeholder="Улица, дом, квартира"
-                      :disabled="creating"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div class="modal-footer modal-footer--stacked">
-                <button type="button" class="btn btn-outline-secondary" @click="closeCreateModal" :disabled="creating">
-                  Отмена
-                </button>
-                <button type="submit" class="btn btn-primary" :disabled="creating">
-                  Сохранить
-                </button>
-              </div>
-            </form>
+    <GlassModal
+      :visible="createModalVisible"
+      max-width="760px"
+      :prevent-close="creating"
+      @close="closeCreateModal"
+    >
+      <form class="form-dialog" @submit.prevent="createUserAction">
+        <header class="form-dialog__header">
+          <div class="form-dialog__heading">
+            <span class="form-dialog__icon form-dialog__icon--accent" aria-hidden="true">
+              <UserPlusIcon />
+            </span>
+            <div class="form-dialog__title-wrap">
+              <DialogTitle id="create-user-modal-title" as="h2" class="form-dialog__title">
+                Новый пользователь
+              </DialogTitle>
+              <p class="form-dialog__subtitle">
+                Укажите контактные данные, роль и временный пароль для новой учетной записи.
+              </p>
+            </div>
           </div>
-        </div>
-      </div>
-      <div v-if="createModalVisible" class="modal-backdrop fade show"></div>
-    </Teleport>
+          <button
+            type="button"
+            class="form-dialog__close"
+            aria-label="Закрыть"
+            :disabled="creating"
+            @click="closeCreateModal"
+          >
+            <XMarkIcon aria-hidden="true" />
+          </button>
+        </header>
+        <section class="form-dialog__body" aria-labelledby="create-user-modal-title">
+          <div class="form-grid">
+            <div class="form-grid__item">
+              <label for="createUserName" class="form-field__label">Имя</label>
+              <input
+                id="createUserName"
+                v-model="createForm.name"
+                type="text"
+                class="form-input"
+                placeholder="Имя и фамилия"
+                required
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserEmail" class="form-field__label">Email</label>
+              <input
+                id="createUserEmail"
+                v-model="createForm.email"
+                type="email"
+                class="form-input"
+                placeholder="name@example.com"
+                required
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserPhone" class="form-field__label">Телефон</label>
+              <input
+                id="createUserPhone"
+                v-model="createForm.phone"
+                type="tel"
+                class="form-input"
+                placeholder="Например, +7 900 000-00-00"
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserRole" class="form-field__label">Роль</label>
+              <select
+                id="createUserRole"
+                v-model="createForm.roleName"
+                class="form-input form-input--select"
+                required
+                :disabled="creating"
+              >
+                <option value="">Выберите роль</option>
+                <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.name }}</option>
+              </select>
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserPassword" class="form-field__label">Пароль</label>
+              <input
+                id="createUserPassword"
+                v-model="createForm.password"
+                type="password"
+                class="form-input"
+                placeholder="Минимум 6 символов"
+                required
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserCountry" class="form-field__label">Страна</label>
+              <input
+                id="createUserCountry"
+                v-model="createForm.country"
+                type="text"
+                class="form-input"
+                placeholder="Например, Россия"
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item">
+              <label for="createUserCity" class="form-field__label">Город</label>
+              <input
+                id="createUserCity"
+                v-model="createForm.city"
+                type="text"
+                class="form-input"
+                placeholder="Например, Москва"
+                :disabled="creating"
+              />
+            </div>
+            <div class="form-grid__item form-grid__item--full">
+              <label for="createUserAddress" class="form-field__label">Адрес</label>
+              <input
+                id="createUserAddress"
+                v-model="createForm.address"
+                type="text"
+                class="form-input"
+                placeholder="Улица, дом, квартира"
+                :disabled="creating"
+              />
+            </div>
+          </div>
+        </section>
+        <footer class="form-dialog__footer">
+          <button
+            type="button"
+            class="dialog-button dialog-button--ghost"
+            :disabled="creating"
+            @click="closeCreateModal"
+          >
+            Отмена
+          </button>
+          <button type="submit" class="dialog-button dialog-button--primary" :disabled="creating">
+            <span v-if="creating">Сохранение...</span>
+            <span v-else>Сохранить</span>
+          </button>
+        </footer>
+      </form>
+    </GlassModal>
 
-    <Teleport to="body">
-      <div
-        v-if="editModalVisible"
-        class="modal fade show glass-modal"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="edit-user-modal-title"
-        @click.self="closeEditModal"
-      >
-        <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <form @submit.prevent="saveUser">
-              <div class="modal-header">
-                <h2 id="edit-user-modal-title" class="modal-title h5 mb-0">Редактирование пользователя</h2>
-                <button type="button" class="btn-close" aria-label="Закрыть" @click="closeEditModal"></button>
-              </div>
-              <div class="modal-body">
-                <div class="modal-form-grid">
-                  <div class="modal-form-grid__item">
-                    <label for="userName" class="form-label">Имя</label>
-                    <input id="userName" v-model="editForm.name" type="text" class="form-control" required />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="userEmail" class="form-label">Email</label>
-                    <input id="userEmail" v-model="editForm.email" type="email" class="form-control" required />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="userPhone" class="form-label">Телефон</label>
-                    <input id="userPhone" v-model="editForm.phone" type="tel" class="form-control" />
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label for="userRole" class="form-label">Роль</label>
-                    <select id="userRole" v-model="editForm.roleName" class="form-select" required>
-                      <option value="">Выберите роль</option>
-                      <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.name }}</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-              <div class="modal-footer modal-footer--stacked">
-                <button type="button" class="btn btn-outline-secondary" @click="closeEditModal">Отмена</button>
-                <button type="submit" class="btn btn-primary" :disabled="saving">Сохранить изменения</button>
-              </div>
-            </form>
+    <GlassModal
+      :visible="editModalVisible"
+      max-width="720px"
+      :prevent-close="saving"
+      @close="closeEditModal"
+    >
+      <form class="form-dialog" @submit.prevent="saveUser">
+        <header class="form-dialog__header">
+          <div class="form-dialog__heading">
+            <span class="form-dialog__icon" aria-hidden="true">
+              <PencilSquareIcon />
+            </span>
+            <div class="form-dialog__title-wrap">
+              <DialogTitle id="edit-user-modal-title" as="h2" class="form-dialog__title">
+                Редактирование пользователя
+              </DialogTitle>
+              <p class="form-dialog__subtitle">Обновите контактные данные и роль пользователя.</p>
+            </div>
           </div>
-        </div>
-      </div>
-      <div v-if="editModalVisible" class="modal-backdrop fade show"></div>
-    </Teleport>
+          <button
+            type="button"
+            class="form-dialog__close"
+            aria-label="Закрыть"
+            :disabled="saving"
+            @click="closeEditModal"
+          >
+            <XMarkIcon aria-hidden="true" />
+          </button>
+        </header>
+        <section class="form-dialog__body" aria-labelledby="edit-user-modal-title">
+          <div class="form-grid form-grid--compact">
+            <div class="form-grid__item">
+              <label for="userName" class="form-field__label">Имя</label>
+              <input id="userName" v-model="editForm.name" type="text" class="form-input" required />
+            </div>
+            <div class="form-grid__item">
+              <label for="userEmail" class="form-field__label">Email</label>
+              <input id="userEmail" v-model="editForm.email" type="email" class="form-input" required />
+            </div>
+            <div class="form-grid__item">
+              <label for="userPhone" class="form-field__label">Телефон</label>
+              <input id="userPhone" v-model="editForm.phone" type="tel" class="form-input" />
+            </div>
+            <div class="form-grid__item">
+              <label for="userRole" class="form-field__label">Роль</label>
+              <select id="userRole" v-model="editForm.roleName" class="form-input form-input--select" required>
+                <option value="">Выберите роль</option>
+                <option v-for="role in roles" :key="role.id" :value="role.name">{{ role.name }}</option>
+              </select>
+            </div>
+          </div>
+        </section>
+        <footer class="form-dialog__footer">
+          <button type="button" class="dialog-button dialog-button--ghost" :disabled="saving" @click="closeEditModal">
+            Отмена
+          </button>
+          <button type="submit" class="dialog-button dialog-button--primary" :disabled="saving">
+            <span v-if="saving">Сохранение...</span>
+            <span v-else>Сохранить изменения</span>
+          </button>
+        </footer>
+      </form>
+    </GlassModal>
 
-    <Teleport to="body">
-      <div
-        v-if="deleteModalVisible"
-        class="modal fade show glass-modal"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="delete-user-modal-title"
-        @click.self="closeDeleteModal"
-      >
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h2 id="delete-user-modal-title" class="modal-title h5 mb-0">Удаление пользователя</h2>
-              <button type="button" class="btn-close" aria-label="Закрыть" @click="closeDeleteModal"></button>
-            </div>
-            <div class="modal-body">
-              <p class="mb-3">Вы уверены, что хотите удалить пользователя «{{ deletingUser?.name }}»?</p>
-              <p class="text-muted mb-0">Это действие нельзя отменить.</p>
-            </div>
-            <div class="modal-footer modal-footer--stacked">
-              <button type="button" class="btn btn-outline-secondary" @click="closeDeleteModal">Отменить</button>
-              <button type="button" class="btn btn-danger" :disabled="deleting" @click="confirmDelete">
-                Удалить
-              </button>
-            </div>
-          </div>
+    <GlassModal
+      :visible="deleteModalVisible"
+      max-width="520px"
+      :prevent-close="deleting"
+      @close="closeDeleteModal"
+    >
+      <div class="confirm-modal">
+        <div class="confirm-modal__icon" aria-hidden="true">
+          <ExclamationTriangleIcon />
+        </div>
+        <DialogTitle id="delete-user-modal-title" as="h2" class="confirm-modal__title">
+          Удалить пользователя?
+        </DialogTitle>
+        <p class="confirm-modal__subtitle">
+          Вы уверены, что хотите удалить пользователя «{{ deletingUser?.name ?? '' }}»? Это действие нельзя отменить.
+        </p>
+        <div class="confirm-modal__actions">
+          <button type="button" class="dialog-button dialog-button--ghost" :disabled="deleting" @click="closeDeleteModal">
+            Отменить
+          </button>
+          <button type="button" class="dialog-button dialog-button--danger" :disabled="deleting" @click="confirmDelete">
+            <span v-if="deleting">Удаление...</span>
+            <span v-else>Удалить</span>
+          </button>
         </div>
       </div>
-      <div v-if="deleteModalVisible" class="modal-backdrop fade show"></div>
-    </Teleport>
+    </GlassModal>
   </div>
 </template>
 
 <script setup lang="ts">
+import { DialogTitle } from '@headlessui/vue';
+import { ExclamationTriangleIcon, PencilSquareIcon, UserPlusIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { onMounted, reactive, ref } from 'vue';
+import GlassModal from '../components/GlassModal.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import {
   createUser,
@@ -312,7 +337,6 @@ import {
   updateUser,
 } from '../api/users';
 import { extractErrorMessage } from '../api/http';
-import { useScrollLock } from '../composables/useScrollLock';
 
 const users = ref<UserListItem[]>([]);
 const roles = ref<UserRole[]>([]);
@@ -327,9 +351,6 @@ const editModalVisible = ref(false);
 const deleteModalVisible = ref(false);
 const createModalVisible = ref(false);
 
-useScrollLock(editModalVisible);
-useScrollLock(deleteModalVisible);
-useScrollLock(createModalVisible);
 const editingUserId = ref<number | null>(null);
 const deletingUser = ref<UserListItem | null>(null);
 
@@ -602,4 +623,5 @@ onMounted(async () => {
     width: 100%;
   }
 }
+
 </style>

--- a/frontend/src/pages/CheckoutPaymentPage.vue
+++ b/frontend/src/pages/CheckoutPaymentPage.vue
@@ -71,150 +71,161 @@
       </div>
     </section>
 
-    <Teleport to="body">
-      <div
-        v-if="showCountryModal"
-        class="modal fade show glass-modal"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="country-limit-modal"
-        @click.self="closeCountryModal"
-      >
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h2 id="country-limit-modal" class="modal-title h5 mb-0">Заказ недоступен</h2>
-              <button type="button" class="btn-close" aria-label="Закрыть" @click="closeCountryModal"></button>
-            </div>
-            <div class="modal-body">
-              <p class="mb-0">{{ countryModalMessage || 'Оформление заказов доступно только пользователям из России.' }}</p>
-            </div>
-            <div class="modal-footer modal-footer--stacked">
-              <button type="button" class="btn btn-outline-secondary" @click="closeCountryModal">Понятно</button>
-              <button type="button" class="btn btn-danger" @click="handleCountryModalProfileRedirect">
-                Перейти в профиль
-              </button>
-            </div>
-          </div>
+        <GlassModal
+      :visible="showCountryModal"
+      max-width="520px"
+      @close="closeCountryModal"
+    >
+      <div class="confirm-modal">
+        <div class="confirm-modal__icon" aria-hidden="true">
+          <GlobeAltIcon />
+        </div>
+        <DialogTitle id="country-limit-modal" as="h2" class="confirm-modal__title">
+          Заказ недоступен
+        </DialogTitle>
+        <p class="confirm-modal__subtitle">
+          {{ countryModalMessage || 'Оформление заказов доступно только пользователям из России.' }}
+        </p>
+        <div class="confirm-modal__actions">
+          <button type="button" class="dialog-button dialog-button--ghost" @click="closeCountryModal">
+            Понятно
+          </button>
+          <button type="button" class="dialog-button dialog-button--danger" @click="handleCountryModalProfileRedirect">
+            Перейти в профиль
+          </button>
         </div>
       </div>
-      <div v-if="showCountryModal" class="modal-backdrop fade show"></div>
-    </Teleport>
+    </GlassModal>
 
-    <Teleport to="body">
-      <div
-        v-if="showAddressModal"
-        class="modal fade show glass-modal"
-        tabindex="-1"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="checkout-address-modal"
-        @click.self="closeAddressModal"
-      >
-        <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <form @submit.prevent="submitAddress">
-              <div class="modal-header">
-                <h2 id="checkout-address-modal" class="modal-title h5 mb-0">Укажите адрес доставки</h2>
-                <button
-                  type="button"
-                  class="btn-close"
-                  aria-label="Закрыть"
-                  @click="closeAddressModal"
-                  :disabled="addressSaving"
-                ></button>
-              </div>
-              <div class="modal-body">
-                <p class="modal-subtitle text-muted">Для оформления заказа заполните все поля.</p>
-                <div class="modal-form-grid">
-                  <div class="modal-form-grid__item">
-                    <label for="checkoutCountry" class="form-label">Страна</label>
-                    <select id="checkoutCountry" v-model="addressForm.country" class="form-select" required>
-                      <option value="">Выберите страну</option>
-                      <option v-for="country in countries" :key="country" :value="country">{{ country }}</option>
-                    </select>
-                  </div>
-                  <div class="modal-form-grid__item">
-                    <label :for="addressForm.useCustomCity ? 'checkoutCityCustom' : 'checkoutCity'" class="form-label">
-                      Город
-                    </label>
-                    <div class="modal-inline-field">
-                      <select
-                        v-if="!addressForm.useCustomCity"
-                        id="checkoutCity"
-                        v-model="addressForm.city"
-                        class="form-select"
-                        :disabled="!addressForm.country"
-                        required
-                      >
-                        <option value="">Выберите город</option>
-                        <option v-for="cityOption in addressCityOptions" :key="cityOption" :value="cityOption">
-                          {{ cityOption }}
-                        </option>
-                      </select>
-                      <input
-                        v-else
-                        id="checkoutCityCustom"
-                        v-model="addressForm.customCity"
-                        type="text"
-                        class="form-control"
-                        placeholder="Введите город"
-                        required
-                      />
-                      <button type="button" class="btn btn-outline-secondary" @click="toggleAddressCityInput">
-                        {{ addressForm.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
-                      </button>
-                    </div>
-                    <small class="text-muted">Выберите город или введите свой</small>
-                  </div>
-                  <div class="modal-form-grid__item modal-form-grid__item--full">
-                    <label for="checkoutAddress" class="form-label">Адрес</label>
-                    <textarea
-                      id="checkoutAddress"
-                      v-model="addressForm.address"
-                      class="form-control"
-                      rows="3"
-                      placeholder="Улица, дом, квартира"
-                      required
-                    ></textarea>
-                  </div>
-                </div>
-                <p v-if="addressError" class="alert alert-danger mt-3 mb-0">{{ addressError }}</p>
-              </div>
-              <div class="modal-footer modal-footer--stacked">
-                <button
-                  type="button"
-                  class="btn btn-outline-secondary"
-                  @click="closeAddressModal"
-                  :disabled="addressSaving"
-                >
-                  Отмена
-                </button>
-                <button type="submit" class="btn btn-danger" :disabled="addressSaving">
-                  {{ addressSaving ? 'Сохранение...' : 'Сохранить адрес' }}
-                </button>
-              </div>
-            </form>
+
+
+        <GlassModal
+      :visible="showAddressModal"
+      max-width="780px"
+      :prevent-close="addressSaving"
+      @close="closeAddressModal"
+    >
+      <form class="form-dialog" @submit.prevent="submitAddress">
+        <header class="form-dialog__header">
+          <div class="form-dialog__heading">
+            <span class="form-dialog__icon" aria-hidden="true">
+              <HomeModernIcon />
+            </span>
+            <div class="form-dialog__title-wrap">
+              <DialogTitle id="checkout-address-modal" as="h2" class="form-dialog__title">
+                Укажите адрес доставки
+              </DialogTitle>
+              <p class="form-dialog__subtitle">Для оформления заказа заполните все поля.</p>
+            </div>
           </div>
-        </div>
-      </div>
-      <div v-if="showAddressModal" class="modal-backdrop fade show"></div>
-    </Teleport>
+          <button
+            type="button"
+            class="form-dialog__close"
+            aria-label="Закрыть"
+            :disabled="addressSaving"
+            @click="closeAddressModal"
+          >
+            <XMarkIcon aria-hidden="true" />
+          </button>
+        </header>
+        <section class="form-dialog__body" aria-labelledby="checkout-address-modal">
+          <div class="form-grid">
+            <div class="form-grid__item">
+              <label for="checkoutCountry" class="form-field__label">Страна</label>
+              <select
+                id="checkoutCountry"
+                v-model="addressForm.country"
+                class="form-input form-input--select"
+                required
+              >
+                <option value="">Выберите страну</option>
+                <option v-for="country in countries" :key="country" :value="country">{{ country }}</option>
+              </select>
+            </div>
+            <div class="form-grid__item">
+              <label :for="addressForm.useCustomCity ? 'checkoutCityCustom' : 'checkoutCity'" class="form-field__label">
+                Город
+              </label>
+              <div class="address-city-field">
+                <select
+                  v-if="!addressForm.useCustomCity"
+                  id="checkoutCity"
+                  v-model="addressForm.city"
+                  class="form-input form-input--select"
+                  :disabled="!addressForm.country"
+                  required
+                >
+                  <option value="">Выберите город</option>
+                  <option v-for="cityOption in addressCityOptions" :key="cityOption" :value="cityOption">
+                    {{ cityOption }}
+                  </option>
+                </select>
+                <input
+                  v-else
+                  id="checkoutCityCustom"
+                  v-model="addressForm.customCity"
+                  type="text"
+                  class="form-input"
+                  placeholder="Введите город"
+                  required
+                />
+                <button
+                  type="button"
+                  class="dialog-button dialog-button--ghost dialog-button--sm address-city-field__toggle"
+                  @click="toggleAddressCityInput"
+                >
+                  {{ addressForm.useCustomCity ? 'Выбрать из списка' : 'Ввести' }}
+                </button>
+              </div>
+              <small class="address-city-field__hint">Выберите город или введите свой</small>
+            </div>
+            <div class="form-grid__item form-grid__item--full">
+              <label for="checkoutAddress" class="form-field__label">Адрес</label>
+              <textarea
+                id="checkoutAddress"
+                v-model="addressForm.address"
+                class="form-input form-input--textarea"
+                rows="3"
+                placeholder="Улица, дом, квартира"
+                required
+              ></textarea>
+            </div>
+          </div>
+          <p v-if="addressError" class="alert alert-danger mt-3 mb-0">{{ addressError }}</p>
+        </section>
+        <footer class="form-dialog__footer">
+          <button
+            type="button"
+            class="dialog-button dialog-button--ghost"
+            :disabled="addressSaving"
+            @click="closeAddressModal"
+          >
+            Отмена
+          </button>
+          <button type="submit" class="dialog-button dialog-button--danger" :disabled="addressSaving">
+            {{ addressSaving ? 'Сохранение...' : 'Сохранить адрес' }}
+          </button>
+        </footer>
+      </form>
+    </GlassModal>
+
+
   </div>
 </template>
 
 <script setup lang="ts">
+import { DialogTitle } from '@headlessui/vue';
+import { GlobeAltIcon, HomeModernIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
+import GlassModal from '../components/GlassModal.vue';
 import { useCartStore } from '../store/cartStore';
 import { useAuthStore } from '../store/authStore';
 import { extractErrorMessage } from '../api/http';
 import { SUPPORTED_COUNTRIES, getCitiesByCountry, isRussianCountry } from '../utils/location';
 import { useNavigation } from '../composables/useNavigation';
-import { useScrollLock } from '../composables/useScrollLock';
 
 const cartStore = useCartStore();
 const { items, totalAmount, totalQuantity, loading, updating, error, lastOrder } = storeToRefs(cartStore);
@@ -243,8 +254,6 @@ const showCountryModal = ref(false);
 const countryModalMessage = ref('');
 const showAddressModal = ref(false);
 
-useScrollLock(showCountryModal);
-useScrollLock(showAddressModal);
 
 const { goToProfile } = useNavigation();
 
@@ -551,6 +560,24 @@ onMounted(() => {
 
 .checkout-summary__line span {
   color: var(--color-text);
+}
+
+.address-city-field {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.address-city-field__toggle {
+  flex: 0 0 auto;
+}
+
+.address-city-field__hint {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
 }
 
 @media (max-width: 991.98px) {

--- a/frontend/src/pages/ManagerPage.vue
+++ b/frontend/src/pages/ManagerPage.vue
@@ -375,321 +375,353 @@
     </div>
   </section>
 
-  <div v-if="addProductModalVisible" class="modal fade show glass-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2 class="modal-title h5 mb-0">Новый товар</h2>
-          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeAddProductModal"></button>
-        </div>
-        <form @submit.prevent="saveNewProduct">
-          <div class="modal-body">
-            <p class="modal-subtitle text-muted">
+  <GlassModal
+    :visible="addProductModalVisible"
+    max-width="920px"
+    :prevent-close="creatingProduct"
+    @close="closeAddProductModal"
+  >
+    <form class="form-dialog manager-modal" @submit.prevent="saveNewProduct">
+      <header class="form-dialog__header">
+        <div class="form-dialog__heading">
+          <span class="form-dialog__icon form-dialog__icon--accent" aria-hidden="true">
+            <PlusCircleIcon />
+          </span>
+          <div class="form-dialog__title-wrap">
+            <DialogTitle id="add-product-modal-title" as="h2" class="form-dialog__title">
+              Новый товар
+            </DialogTitle>
+            <p class="form-dialog__subtitle">
               Заполните карточку товара. Все поля можно отредактировать в любой момент.
             </p>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="newProductTitle" class="form-label">Название</label>
-                <input
-                  id="newProductTitle"
-                  v-model="addProductForm.title"
-                  type="text"
-                  class="form-control"
-                  placeholder="Например, Толстовка Slipknot"
-                  required
-                  :disabled="creatingProduct"
-                />
-              </div>
-              <div class="col-md-6">
-                <label for="newProductSku" class="form-label">Артикул</label>
-                <input
-                  id="newProductSku"
-                  v-model="addProductForm.sku"
-                  type="text"
-                  class="form-control"
-                  placeholder="SKU-001"
-                  required
-                  :disabled="creatingProduct"
-                />
-              </div>
-              <div class="col-md-4">
-                <label for="newProductPrice" class="form-label">Цена (₽)</label>
-                <input
-                  id="newProductPrice"
-                  v-model="addProductForm.price"
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  class="form-control"
-                  required
-                  :disabled="creatingProduct"
-                />
-              </div>
-              <div class="col-md-4">
-                <label for="newProductCategory" class="form-label">Категория</label>
-                <select
-                  id="newProductCategory"
-                  v-model="addProductForm.categoryId"
-                  class="form-select"
-                  required
-                  :disabled="creatingProduct"
-                >
-                  <option value="">Выберите категорию</option>
-                  <option v-for="category in categories" :key="category.id" :value="String(category.id)">
-                    {{ category.name }}
-                  </option>
-                </select>
-              </div>
-              <div class="col-12">
-                <div class="manager-sizes">
-                  <div class="manager-sizes__header">
-                    <label class="form-label mb-0">Размеры и остатки</label>
-                    <button
-                      type="button"
-                      class="btn btn-outline-secondary btn-sm"
-                      @click="addSizeRow(addProductForm.sizes)"
-                      :disabled="creatingProduct"
-                    >
-                      Добавить размер
-                    </button>
-                  </div>
-                  <div class="manager-sizes__list">
-                    <div
-                      v-for="(sizeRow, index) in addProductForm.sizes"
-                      :key="sizeRow.id ?? `new-product-size-${index}`"
-                      class="manager-sizes__row row g-3 align-items-end"
-                    >
-                      <div class="col-md-4 col-sm-6">
-                        <label
-                          class="form-label"
-                          :for="`newProductSizeName-${index}`"
-                        >
-                          Размер
-                        </label>
-                        <input
-                          :id="`newProductSizeName-${index}`"
-                          v-model="sizeRow.size"
-                          type="text"
-                          class="form-control"
-                          placeholder="Например, M"
-                          maxlength="20"
-                          :disabled="creatingProduct"
-                        />
-                      </div>
-                      <div class="col-md-3 col-sm-6">
-                        <label
-                          class="form-label"
-                          :for="`newProductSizePrice-${index}`"
-                        >
-                          Цена, ₽
-                        </label>
-                        <input
-                          :id="`newProductSizePrice-${index}`"
-                          v-model="sizeRow.price"
-                          type="number"
-                          min="0"
-                          step="0.01"
-                          class="form-control"
-                          placeholder="0.00"
-                          :disabled="creatingProduct"
-                        />
-                      </div>
-                      <div class="col-md-3 col-sm-6">
-                        <label
-                          class="form-label"
-                          :for="`newProductSizeStock-${index}`"
-                        >
-                          Остаток
-                        </label>
-                        <input
-                          :id="`newProductSizeStock-${index}`"
-                          v-model="sizeRow.stock"
-                          type="number"
-                          min="0"
-                          class="form-control"
-                          :disabled="creatingProduct"
-                        />
-                      </div>
-                      <div class="col-md-2 col-sm-4">
-                        <button
-                          type="button"
-                          class="btn btn-outline-danger mt-4 w-100"
-                          @click="removeSizeRow(addProductForm.sizes, index)"
-                          :disabled="creatingProduct"
-                        >
-                          Удалить
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-8">
-                <label for="newProductImage" class="form-label">Ссылка на изображение</label>
-                <input
-                  id="newProductImage"
-                  v-model="addProductForm.imageUrl"
-                  type="url"
-                  class="form-control"
-                  placeholder="https://"
-                  :disabled="creatingProduct"
-                />
-              </div>
-              <div class="col-12">
-                <label for="newProductDescription" class="form-label">Описание</label>
-                <textarea
-                  id="newProductDescription"
-                  v-model="addProductForm.description"
-                  class="form-control"
-                  rows="3"
-                  placeholder="Коротко опишите товар"
-                  :disabled="creatingProduct"
-                ></textarea>
-              </div>
-            </div>
           </div>
-          <div class="modal-footer modal-footer--stacked">
-            <button type="button" class="btn btn-outline-secondary" @click="closeAddProductModal" :disabled="creatingProduct">
-              Отмена
-            </button>
-            <button type="submit" class="btn btn-primary" :disabled="creatingProduct">
-              Сохранить
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  </div>
-  <div v-if="addProductModalVisible" class="modal-backdrop fade show"></div>
-
-  <div v-if="addOrderModalVisible" class="modal fade show glass-modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2 class="modal-title h5 mb-0">Новый заказ</h2>
-          <button type="button" class="btn-close" aria-label="Закрыть" @click="closeAddOrderModal"></button>
         </div>
-        <form @submit.prevent="saveNewOrder">
-          <div class="modal-body">
-            <p class="modal-subtitle text-muted">
-              Создайте новый заказ и зафиксируйте ключевые данные клиента и доставки.
-            </p>
-            <div class="row g-3">
-              <div class="col-md-6">
-                <label for="newOrderUser" class="form-label">Покупатель</label>
-                <select
-                  id="newOrderUser"
-                  v-model="addOrderForm.userId"
-                  class="form-select"
-                  required
-                  :disabled="creatingOrder || !orderCustomers.length"
-                >
-                  <option value="">Выберите покупателя</option>
-                  <option v-for="customer in orderCustomers" :key="customer.id" :value="String(customer.id)">
-                    {{ customer.name }} • {{ customer.email }}
-                  </option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="newOrderStatus" class="form-label">Статус</label>
-                <select
-                  id="newOrderStatus"
-                  v-model="addOrderForm.statusId"
-                  class="form-select"
-                  required
-                  :disabled="creatingOrder"
-                >
-                  <option value="">Выберите статус</option>
-                  <option v-for="status in orderStatuses" :key="status.id" :value="String(status.id)">
-                    {{ status.name }}
-                  </option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="newOrderShipping" class="form-label">Статус отправки</label>
-                <select
-                  id="newOrderShipping"
-                  v-model="addOrderForm.shippingStatus"
-                  class="form-select"
-                  required
-                  :disabled="creatingOrder"
-                >
-                  <option v-for="option in shippingStatusOptions" :key="option" :value="option">
-                    {{ option }}
-                  </option>
-                </select>
-              </div>
-              <div class="col-md-6">
-                <label for="newOrderTotal" class="form-label">Сумма (₽)</label>
+        <button
+          type="button"
+          class="form-dialog__close"
+          aria-label="Закрыть"
+          :disabled="creatingProduct"
+          @click="closeAddProductModal"
+        >
+          <XMarkIcon aria-hidden="true" />
+        </button>
+      </header>
+      <section class="form-dialog__body manager-modal__body" aria-labelledby="add-product-modal-title">
+        <div class="form-grid manager-form-grid">
+          <div class="form-grid__item">
+            <label for="newProductTitle" class="form-field__label">Название</label>
+            <input
+              id="newProductTitle"
+              v-model="addProductForm.title"
+              type="text"
+              class="form-input"
+              placeholder="Например, Толстовка Slipknot"
+              required
+              :disabled="creatingProduct"
+            />
+          </div>
+          <div class="form-grid__item">
+            <label for="newProductSku" class="form-field__label">Артикул</label>
+            <input
+              id="newProductSku"
+              v-model="addProductForm.sku"
+              type="text"
+              class="form-input"
+              placeholder="SKU-001"
+              required
+              :disabled="creatingProduct"
+            />
+          </div>
+          <div class="form-grid__item">
+            <label for="newProductPrice" class="form-field__label">Цена (₽)</label>
+            <input
+              id="newProductPrice"
+              v-model="addProductForm.price"
+              type="number"
+              min="0"
+              step="0.01"
+              class="form-input"
+              required
+              :disabled="creatingProduct"
+            />
+          </div>
+          <div class="form-grid__item">
+            <label for="newProductCategory" class="form-field__label">Категория</label>
+            <select
+              id="newProductCategory"
+              v-model="addProductForm.categoryId"
+              class="form-input form-input--select"
+              required
+              :disabled="creatingProduct"
+            >
+              <option value="">Выберите категорию</option>
+              <option v-for="category in categories" :key="category.id" :value="String(category.id)">
+                {{ category.name }}
+              </option>
+            </select>
+          </div>
+          <div class="form-grid__item form-grid__item--full">
+            <label for="newProductImage" class="form-field__label">Ссылка на изображение</label>
+            <input
+              id="newProductImage"
+              v-model="addProductForm.imageUrl"
+              type="url"
+              class="form-input"
+              placeholder="https://"
+              :disabled="creatingProduct"
+            />
+          </div>
+          <div class="form-grid__item form-grid__item--full">
+            <label for="newProductDescription" class="form-field__label">Описание</label>
+            <textarea
+              id="newProductDescription"
+              v-model="addProductForm.description"
+              class="form-input form-input--textarea"
+              rows="3"
+              placeholder="Короткое описание товара"
+              :disabled="creatingProduct"
+            ></textarea>
+          </div>
+        </div>
+        <div class="manager-sizes">
+          <div class="manager-sizes__header">
+            <h3 class="manager-sizes__title">Размеры и остатки</h3>
+            <button
+              type="button"
+              class="dialog-button dialog-button--ghost dialog-button--sm"
+              @click="addSizeRow(addProductForm.sizes)"
+              :disabled="creatingProduct"
+            >
+              Добавить размер
+            </button>
+          </div>
+          <div class="manager-sizes__list">
+            <div
+              v-for="(sizeRow, index) in addProductForm.sizes"
+              :key="sizeRow.id ?? `new-product-size-${index}`"
+              class="manager-sizes__row"
+            >
+              <div class="manager-sizes__field">
+                <label class="form-field__label" :for="`newProductSizeName-${index}`">Размер</label>
                 <input
-                  id="newOrderTotal"
-                  v-model="addOrderForm.totalAmount"
+                  :id="`newProductSizeName-${index}`"
+                  v-model="sizeRow.size"
+                  type="text"
+                  class="form-input"
+                  placeholder="Например, M"
+                  maxlength="20"
+                  :disabled="creatingProduct"
+                />
+              </div>
+              <div class="manager-sizes__field">
+                <label class="form-field__label" :for="`newProductSizePrice-${index}`">Цена (₽)</label>
+                <input
+                  :id="`newProductSizePrice-${index}`"
+                  v-model="sizeRow.price"
                   type="number"
                   min="0"
                   step="0.01"
-                  class="form-control"
-                  required
-                  :disabled="creatingOrder"
+                  class="form-input"
+                  :disabled="creatingProduct"
                 />
               </div>
-              <div class="col-md-6">
-                <label for="newOrderPayment" class="form-label">Способ оплаты</label>
+              <div class="manager-sizes__field">
+                <label class="form-field__label" :for="`newProductSizeStock-${index}`">Остаток</label>
                 <input
-                  id="newOrderPayment"
-                  v-model="addOrderForm.paymentMethod"
-                  type="text"
-                  class="form-control"
-                  placeholder="Например, Банковская карта"
-                  :disabled="creatingOrder"
-                />
-              </div>
-              <div class="col-md-6">
-                <label for="newOrderAddress" class="form-label">ID адреса (опционально)</label>
-                <input
-                  id="newOrderAddress"
-                  v-model="addOrderForm.addressId"
+                  :id="`newProductSizeStock-${index}`"
+                  v-model="sizeRow.stock"
                   type="number"
-                  min="1"
-                  class="form-control"
-                  placeholder="Укажите при необходимости"
-                  :disabled="creatingOrder"
+                  min="0"
+                  class="form-input"
+                  :disabled="creatingProduct"
                 />
               </div>
-              <div class="col-12">
-                <label for="newOrderComment" class="form-label">Комментарий</label>
-                <textarea
-                  id="newOrderComment"
-                  v-model="addOrderForm.comment"
-                  class="form-control"
-                  rows="3"
-                  placeholder="Дополнительная информация для сборки или доставки"
-                  :disabled="creatingOrder"
-                ></textarea>
-              </div>
-              <div v-if="!orderCustomers.length" class="col-12">
-                <div class="manager-modal__empty">
-                  Нет доступных покупателей. Добавьте пользователя в разделе администрирования.
-                </div>
-              </div>
+              <button
+                type="button"
+                class="dialog-button dialog-button--danger dialog-button--sm manager-sizes__remove"
+                @click="removeSizeRow(addProductForm.sizes, index)"
+                :disabled="creatingProduct || addProductForm.sizes.length <= 1"
+              >
+                Удалить
+              </button>
             </div>
           </div>
-          <div class="modal-footer modal-footer--stacked">
-            <button type="button" class="btn btn-outline-secondary" @click="closeAddOrderModal" :disabled="creatingOrder">
-              Отмена
-            </button>
-            <button type="submit" class="btn btn-primary" :disabled="creatingOrder || !orderCustomers.length">
-              Сохранить
-            </button>
+        </div>
+      </section>
+      <footer class="form-dialog__footer">
+        <button
+          type="button"
+          class="dialog-button dialog-button--ghost"
+          :disabled="creatingProduct"
+          @click="closeAddProductModal"
+        >
+          Отмена
+        </button>
+        <button type="submit" class="dialog-button dialog-button--primary" :disabled="creatingProduct">
+          <span v-if="creatingProduct">Сохранение...</span>
+          <span v-else>Сохранить</span>
+        </button>
+      </footer>
+    </form>
+  </GlassModal>
+
+  <GlassModal
+    :visible="addOrderModalVisible"
+    max-width="820px"
+    :prevent-close="creatingOrder"
+    @close="closeAddOrderModal"
+  >
+    <form class="form-dialog manager-modal" @submit.prevent="saveNewOrder">
+      <header class="form-dialog__header">
+        <div class="form-dialog__heading">
+          <span class="form-dialog__icon" aria-hidden="true">
+            <ClipboardDocumentListIcon />
+          </span>
+          <div class="form-dialog__title-wrap">
+            <DialogTitle id="add-order-modal-title" as="h2" class="form-dialog__title">
+              Новый заказ
+            </DialogTitle>
+            <p class="form-dialog__subtitle">
+              Укажите клиента, статусы и сумму заказа. Эти параметры можно изменить позже.
+            </p>
           </div>
-        </form>
-      </div>
-    </div>
-  </div>
-  <div v-if="addOrderModalVisible" class="modal-backdrop fade show"></div>
+        </div>
+        <button
+          type="button"
+          class="form-dialog__close"
+          aria-label="Закрыть"
+          :disabled="creatingOrder"
+          @click="closeAddOrderModal"
+        >
+          <XMarkIcon aria-hidden="true" />
+        </button>
+      </header>
+      <section class="form-dialog__body manager-modal__body" aria-labelledby="add-order-modal-title">
+        <div class="form-grid manager-form-grid">
+          <div class="form-grid__item">
+            <label for="newOrderUser" class="form-field__label">Покупатель</label>
+            <select
+              id="newOrderUser"
+              v-model="addOrderForm.userId"
+              class="form-input form-input--select"
+              required
+              :disabled="creatingOrder || !orderCustomers.length"
+            >
+              <option value="">Выберите покупателя</option>
+              <option v-for="customer in orderCustomers" :key="customer.id" :value="String(customer.id)">
+                {{ customer.name }} • {{ customer.email }}
+              </option>
+            </select>
+          </div>
+          <div class="form-grid__item">
+            <label for="newOrderStatus" class="form-field__label">Статус</label>
+            <select
+              id="newOrderStatus"
+              v-model="addOrderForm.statusId"
+              class="form-input form-input--select"
+              required
+              :disabled="creatingOrder"
+            >
+              <option value="">Выберите статус</option>
+              <option v-for="status in orderStatuses" :key="status.id" :value="String(status.id)">
+                {{ status.name }}
+              </option>
+            </select>
+          </div>
+          <div class="form-grid__item">
+            <label for="newOrderShipping" class="form-field__label">Статус отправки</label>
+            <select
+              id="newOrderShipping"
+              v-model="addOrderForm.shippingStatus"
+              class="form-input form-input--select"
+              required
+              :disabled="creatingOrder"
+            >
+              <option v-for="option in shippingStatusOptions" :key="option" :value="option">
+                {{ option }}
+              </option>
+            </select>
+          </div>
+          <div class="form-grid__item">
+            <label for="newOrderTotal" class="form-field__label">Сумма (₽)</label>
+            <input
+              id="newOrderTotal"
+              v-model="addOrderForm.totalAmount"
+              type="number"
+              min="0"
+              step="0.01"
+              class="form-input"
+              required
+              :disabled="creatingOrder"
+            />
+          </div>
+          <div class="form-grid__item">
+            <label for="newOrderPayment" class="form-field__label">Способ оплаты</label>
+            <input
+              id="newOrderPayment"
+              v-model="addOrderForm.paymentMethod"
+              type="text"
+              class="form-input"
+              placeholder="Например, Банковская карта"
+              :disabled="creatingOrder"
+            />
+          </div>
+          <div class="form-grid__item">
+            <label for="newOrderAddress" class="form-field__label">ID адреса (опционально)</label>
+            <input
+              id="newOrderAddress"
+              v-model="addOrderForm.addressId"
+              type="number"
+              min="1"
+              class="form-input"
+              placeholder="Укажите при необходимости"
+              :disabled="creatingOrder"
+            />
+          </div>
+          <div class="form-grid__item form-grid__item--full">
+            <label for="newOrderComment" class="form-field__label">Комментарий</label>
+            <textarea
+              id="newOrderComment"
+              v-model="addOrderForm.comment"
+              class="form-input form-input--textarea"
+              rows="3"
+              placeholder="Дополнительная информация для сборки или доставки"
+              :disabled="creatingOrder"
+            ></textarea>
+          </div>
+        </div>
+        <div v-if="!orderCustomers.length" class="manager-modal__empty">
+          Нет доступных покупателей. Добавьте пользователя в разделе администрирования.
+        </div>
+      </section>
+      <footer class="form-dialog__footer">
+        <button
+          type="button"
+          class="dialog-button dialog-button--ghost"
+          :disabled="creatingOrder"
+          @click="closeAddOrderModal"
+        >
+          Отмена
+        </button>
+        <button
+          type="submit"
+          class="dialog-button dialog-button--primary"
+          :disabled="creatingOrder || !orderCustomers.length"
+        >
+          <span v-if="creatingOrder">Сохранение...</span>
+          <span v-else>Сохранить</span>
+        </button>
+      </footer>
+    </form>
+  </GlassModal>
+
 </template>
 
 <script setup lang="ts">
+import { DialogTitle } from '@headlessui/vue';
+import { ClipboardDocumentListIcon, PlusCircleIcon, XMarkIcon } from '@heroicons/vue/24/outline';
 import { onMounted, reactive, ref } from 'vue';
+import GlassModal from '../components/GlassModal.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import {
   fetchProducts,
@@ -716,7 +748,6 @@ import {
   type UpdateOrderPayload,
 } from '../api/orders';
 import { extractErrorMessage } from '../api/http';
-import { useScrollLock } from '../composables/useScrollLock';
 
 interface EditableProductSize {
   id: number | null;
@@ -788,8 +819,6 @@ const orderForm = ref<OrderFormState | null>(null);
 const addProductModalVisible = ref(false);
 const addOrderModalVisible = ref(false);
 
-useScrollLock(addProductModalVisible);
-useScrollLock(addOrderModalVisible);
 const addProductForm = reactive<NewProductFormState>({
   title: '',
   description: '',
@@ -1340,14 +1369,31 @@ onMounted(() => {
   font-weight: 600;
 }
 
+.manager-modal {
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.manager-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.manager-form-grid {
+  gap: clamp(1rem, 2vw, 1.35rem);
+}
+
 .manager-sizes {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem;
-  border-radius: var(--radius-lg);
-  border: 1px dashed color-mix(in srgb, var(--color-accent) 35%, transparent);
-  background: color-mix(in srgb, var(--color-surface-alt) 85%, transparent);
+  padding: clamp(1rem, 2.5vw, 1.35rem);
+  border-radius: calc(var(--radius-lg) * 1.1);
+  border: 1px dashed color-mix(in srgb, var(--color-accent) 38%, transparent);
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--color-surface-alt) 88%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface) 78%, transparent) 100%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 65%, transparent);
 }
 
 .manager-sizes__header {
@@ -1355,16 +1401,37 @@ onMounted(() => {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.manager-sizes__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
 }
 
 .manager-sizes__list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.9rem;
 }
 
 .manager-sizes__row {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 0.9rem;
+  align-items: end;
+}
+
+.manager-sizes__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.manager-sizes__remove {
+  align-self: stretch;
+  min-width: 0;
 }
 
 .manager-modal__empty {
@@ -1374,6 +1441,16 @@ onMounted(() => {
   background: color-mix(in srgb, var(--color-accent) 18%, transparent);
   color: var(--color-text-muted);
   text-align: center;
+}
+
+@media (max-width: 768px) {
+  .manager-sizes__row {
+    grid-template-columns: 1fr;
+  }
+
+  .manager-sizes__remove {
+    justify-self: stretch;
+  }
 }
 
 @media (max-width: 575.98px) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -191,6 +191,321 @@ select {
   z-index: -1;
 }
 
+.form-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.form-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.form-dialog__heading {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.85rem, 2vw, 1.15rem);
+}
+
+.form-dialog__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(48px, 10vw, 60px);
+  height: clamp(48px, 10vw, 60px);
+  border-radius: 18px;
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-surface) 80%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt) 85%, transparent) 100%);
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 85%, transparent);
+}
+
+.form-dialog__icon--accent {
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-accent) 35%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong) 22%, transparent) 100%),
+    linear-gradient(140deg, color-mix(in srgb, var(--color-surface) 72%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt) 62%, transparent) 100%);
+  color: color-mix(in srgb, var(--color-text) 96%, transparent);
+}
+
+.form-dialog__icon :is(svg) {
+  width: clamp(28px, 6vw, 32px);
+  height: clamp(28px, 6vw, 32px);
+}
+
+.form-dialog__title-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.form-dialog__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.15rem + 0.6vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: color-mix(in srgb, var(--color-text) 96%, transparent);
+}
+
+.form-dialog__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--color-text-muted) 92%, transparent);
+}
+
+.form-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  border: none;
+  background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  box-shadow: var(--shadow-inset);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-dialog__close:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-dialog__close:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow:
+    var(--shadow-inset),
+    0 12px 30px -18px color-mix(in srgb, var(--color-accent) 28%, transparent);
+}
+
+.form-dialog__close svg {
+  width: 22px;
+  height: 22px;
+}
+
+.form-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.form-grid--compact {
+  gap: 1rem;
+}
+
+.form-grid__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.form-grid__item--full {
+  grid-column: 1 / -1;
+}
+
+.form-field__label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: color-mix(in srgb, var(--color-text-muted) 92%, transparent);
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--color-surface-border) 55%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+  color: color-mix(in srgb, var(--color-text) 94%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 65%, transparent);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-surface-border));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 75%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--color-outline) 55%, transparent);
+}
+
+.form-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-input--select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position: calc(100% - 1.3rem) 50%, calc(100% - 0.9rem) 50%;
+  background-size: 8px 8px, 8px 8px;
+  background-repeat: no-repeat;
+  padding-right: 2.5rem;
+}
+
+.form-input--textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.form-dialog__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.dialog-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.8rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.dialog-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dialog-button--ghost {
+  background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+  color: color-mix(in srgb, var(--color-text) 92%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 70%, transparent),
+    0 8px 26px -18px color-mix(in srgb, var(--color-accent) 25%, transparent);
+}
+
+.dialog-button--ghost:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-surface-border) 85%, transparent),
+    0 16px 38px -22px color-mix(in srgb, var(--color-accent) 26%, transparent);
+}
+
+.dialog-button--primary {
+  background: linear-gradient(140deg, color-mix(in srgb, var(--color-accent) 60%, transparent) 0%,
+      color-mix(in srgb, var(--color-accent-strong) 45%, transparent) 100%);
+  color: #fff;
+  box-shadow:
+    0 22px 44px -24px color-mix(in srgb, var(--color-accent) 68%, transparent),
+    inset 0 1px 0 color-mix(in srgb, rgba(255, 255, 255, 0.9) 80%, transparent);
+}
+
+.dialog-button--primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    0 28px 52px -22px color-mix(in srgb, var(--color-accent) 72%, transparent),
+    inset 0 1px 0 color-mix(in srgb, rgba(255, 255, 255, 0.95) 88%, transparent);
+}
+
+.dialog-button--danger {
+  background: linear-gradient(140deg, color-mix(in srgb, var(--color-danger) 62%, transparent) 0%,
+      color-mix(in srgb, var(--color-danger) 46%, transparent) 100%);
+  color: #fff;
+  box-shadow:
+    0 20px 46px -22px color-mix(in srgb, var(--color-danger) 68%, transparent),
+    inset 0 1px 0 color-mix(in srgb, rgba(255, 255, 255, 0.9) 78%, transparent);
+}
+
+.dialog-button--danger:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow:
+    0 28px 54px -24px color-mix(in srgb, var(--color-danger) 72%, transparent),
+    inset 0 1px 0 color-mix(in srgb, rgba(255, 255, 255, 0.92) 84%, transparent);
+}
+
+.dialog-button--sm {
+  padding: 0.6rem 1.15rem;
+  font-size: 0.85rem;
+}
+
+.confirm-modal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.1rem;
+}
+
+.confirm-modal__icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    linear-gradient(140deg, color-mix(in srgb, var(--color-danger) 65%, transparent) 0%,
+      color-mix(in srgb, var(--color-danger) 42%, transparent) 100%),
+    linear-gradient(140deg, color-mix(in srgb, var(--color-surface) 80%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-alt) 65%, transparent) 100%);
+  color: #fff;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, rgba(255, 255, 255, 0.8) 80%, transparent);
+}
+
+.confirm-modal__icon svg {
+  width: 32px;
+  height: 32px;
+}
+
+.confirm-modal__title {
+  margin: 0;
+  font-size: clamp(1.25rem, 1.1rem + 0.4vw, 1.45rem);
+  font-weight: 600;
+  color: color-mix(in srgb, var(--color-text) 96%, transparent);
+}
+
+.confirm-modal__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: color-mix(in srgb, var(--color-text-muted) 94%, transparent);
+}
+
+.confirm-modal__actions {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+@media (max-width: 900px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .form-dialog__footer {
+    justify-content: stretch;
+  }
+
+  .dialog-button {
+    flex: 1 0 auto;
+    width: 100%;
+  }
+}
+
 .fade-in-up {
   animation: fadeInUp 0.8s ease forwards;
   opacity: 0;


### PR DESCRIPTION
## Summary
- add a reusable `GlassModal` wrapper with glassmorphism backdrop, motion, and scroll locking
- migrate admin, manager, checkout, and product confirmation dialogs to the shared modal structure and actions
- extend shared dialog button and confirmation styles to match the new modal system

## Testing
- npm run build
- curl -s http://127.0.0.1:3000/products | head

------
https://chatgpt.com/codex/tasks/task_e_68f89b586ff883219f81151240b9c50f