### PR TITLE
Enable live product search without page reload

### DIFF
--- a/backend/src/modules/products/products.controller.ts
+++ b/backend/src/modules/products/products.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -55,8 +56,8 @@ export class ProductsController {
     type: ProductResponseDto,
     isArray: true,
   })
-  findAll(): Promise<ProductResponseDto[]> {
-    return this.productsService.findAll();
+  findAll(@Query('search') search?: string): Promise<ProductResponseDto[]> {
+    return this.productsService.findAll(search);
   }
 
   @Get(':id')

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -33,8 +33,10 @@ export interface ProductSizePayload {
   stock: number;
 }
 
-export const fetchProducts = async (): Promise<ProductDto[]> => {
-  const { data } = await http.get<ProductDto[]>('/products');
+export const fetchProducts = async (search?: string): Promise<ProductDto[]> => {
+  const { data } = await http.get<ProductDto[]>('/products', {
+    params: search ? { search } : undefined,
+  });
   return data;
 };
 


### PR DESCRIPTION
## Summary
- add optional search parameter to the products API and filter results on the server
- update the frontend store and catalog page to fetch debounced results without router reloads
- hide the native search cancel control so that only the custom clear button is shown

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68f943fcbc9c8321b75f4ed0ba8b9f6b