### PR TITLE
feat: support admin-triggered database restore

### DIFF
--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -17,3 +17,19 @@ export const downloadSalesExcel = async (): Promise<AxiosResponse<Blob>> => {
     responseType: 'blob',
   });
 };
+
+export const downloadDatabaseBackup = async (): Promise<AxiosResponse<Blob>> => {
+  return http.post('/reports/database/backup', undefined, {
+    responseType: 'blob',
+  });
+};
+
+export interface RestoreDatabaseResponse {
+  message: string;
+}
+
+export const restoreDatabaseFromScript = async (): Promise<
+  AxiosResponse<RestoreDatabaseResponse>
+> => {
+  return http.post('/reports/database/restore');
+};


### PR DESCRIPTION
## Summary
- add an admin reports endpoint that replays restore.sql or schema.sql to reset the database
- wire the API client, store, and reports page with admin-only restore controls and messaging
- surface detailed success and error states for backup and restore actions on the frontend

## Testing
- npm run test -- --runTestsByPath --passWithNoTests
- curl -s -D - -X POST http://localhost:3000/reports/database/backup -H "Authorization: Bearer <token>"
- curl -s -D - -X POST http://localhost:3000/reports/database/restore -H "Authorization: Bearer <token>"

------
https://chatgpt.com/codex/tasks/task_e_68f9ed8473a48321bf4af20487b8e7f4