### PR TITLE
fix: allow configuring postgres utilities for database tools

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -94,6 +94,19 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 - Website - [https://nestjs.com](https://nestjs.com/)
 - Twitter - [@nestframework](https://twitter.com/nestframework)
 
+## Database maintenance helpers
+
+Для корректной работы функций "Создать бэкап БД" и "Сбросить БД" необходимо, чтобы утилиты
+`pg_dump` и `psql` были доступны в системе. Если они не прописаны в `PATH`, укажите путь явно
+через переменные окружения:
+
+- `POSTGRES_BIN_PATH` / `PG_BIN_PATH` / `POSTGRESQL_BIN_PATH` — путь до каталога `bin` PostgreSQL.
+- `POSTGRES_PG_DUMP_PATH` или `PG_PG_DUMP_PATH` — полный путь до исполняемого файла `pg_dump`.
+- `POSTGRES_PSQL_PATH` или `PG_PSQL_PATH` — полный путь до исполняемого файла `psql`.
+
+Переменные со специфичным файлом имеют приоритет над каталогом. На Windows можно указывать путь
+к `.exe` файлам (например, `C:\\Program Files\\PostgreSQL\\16\\bin\\psql.exe`).
+
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).


### PR DESCRIPTION
## Summary
- allow configuring pg_dump and psql paths via new helper logic in reports service
- improve error messages when postgres client binaries are missing
- document the new environment variables for configuring postgres client executables

## Testing
- npm run test
- npx ts-node -e "import { NestFactory } from '@nestjs/core'; import { AppModule } from './src/app.module'; import { ReportsService } from './src/modules/reports/reports.service'; (async () => { const app = await NestFactory.createApplicationContext(AppModule); const service = app.get(ReportsService); const backup = await service.createDatabaseBackup(); console.log('backup-bytes', backup.buffer.length); const source = await service.restoreDatabaseFromScript(); console.log('restore-source', source); await app.close(); })();"

------
https://chatgpt.com/codex/tasks/task_e_68f9fe0ada848321840d91b65b479692