### PR TITLE
feat: generate database backups without pg_dump

### DIFF
--- a/backend/database/backup.sql
+++ b/backend/database/backup.sql
@@ -1,2 +1,2 @@
--- Manual backup script for Slipknot merch database
-\! pg_dump -h "$DATABASE_HOST" -p "${DATABASE_PORT:-5432}" -U "$DATABASE_USER" "$DATABASE_NAME" > backup.sql
+-- Placeholder backup file. It will be overwritten automatically when an administrator generates a database backup from the reports panel.
+-- The generated script contains SQL statements that recreate the data in the public schema.

--- a/backend/database/restore.sql
+++ b/backend/database/restore.sql
@@ -1,2 +1,3 @@
--- Manual restore script for Slipknot merch database
-\! psql -h "$DATABASE_HOST" -p "${DATABASE_PORT:-5432}" -U "$DATABASE_USER" -d "$DATABASE_NAME" -f backup.sql
+-- Placeholder manual restore helper.
+-- The NestJS reports module now executes SQL scripts directly, so this file no longer runs psql commands.
+-- Keep schema.sql up to date; restore operations will fall back to it if no generated backup is found.

--- a/frontend/src/pages/ReportsPage.vue
+++ b/frontend/src/pages/ReportsPage.vue
@@ -421,7 +421,7 @@ const resetBackup = () => {
 
 const handleRestore = async () => {
   const confirmed = window.confirm(
-    'Сброс базы данных восстановит состояние из restore.sql и удалит текущие данные. Продолжить?',
+    'Сброс базы данных восстановит состояние из последнего бэкапа (если он существует) или schema.sql и удалит текущие данные. Продолжить?',
   );
   if (!confirmed) {
     return;


### PR DESCRIPTION
## Summary
- replace the reports backup process with a SQL dump generator that no longer requires pg_dump
- execute backup and schema scripts directly through TypeORM to support in-app restores
- document the placeholder database scripts and clarify the admin restore confirmation copy

## Testing
- npm run lint
- curl -X POST /reports/database/backup
- curl -X POST /reports/database/restore

------
https://chatgpt.com/codex/tasks/task_e_68fa7329b1a88321b963a81cc1153c74