### PR TITLE
Fix profile phone field sanitization

### DIFF
--- a/frontend/src/pages/ProfilePage.vue
+++ b/frontend/src/pages/ProfilePage.vue
@@ -60,6 +60,7 @@
                     id="profilePhone"
                     v-model="form.phone"
                     type="tel"
+                    inputmode="tel"
                     class="form-control"
                     placeholder="Например, +7 900 000-00-00"
                     maxlength="30"
@@ -170,6 +171,8 @@ const route = useRoute();
 
 const countries = [...SUPPORTED_COUNTRIES];
 
+const ALLOWED_PHONE_CHARACTERS = /[^\d+()\-\s]/g;
+
 const form = reactive({
   name: '',
   email: '',
@@ -269,6 +272,19 @@ watch(user, (value) => {
   }
   form.address = value.address ?? '';
 });
+
+watch(
+  () => form.phone,
+  (value) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+    const sanitized = value.replace(ALLOWED_PHONE_CHARACTERS, '');
+    if (sanitized !== value) {
+      form.phone = sanitized;
+    }
+  },
+);
 
 watch(error, (value) => {
   if (value) {


### PR DESCRIPTION
## Summary
- restrict the profile phone input to allow only digits and phone punctuation while editing
- add an explicit telephone input mode for improved mobile keyboard support

## Testing
- npm run start:dev
- npm run dev -- --host 0.0.0.0 --port 5173
- curl -I http://127.0.0.1:3000/
- curl -I http://127.0.0.1:5173/
- playwright scenario: login and verify phone sanitization


------
https://chatgpt.com/codex/tasks/task_e_68fb5f33243083219d49620f6593b2a9