### PR TITLE
Add keyboard shortcuts for navbar navigation

### DIFF
--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -15,35 +15,11 @@
       </button>
       <div class="collapse navbar-collapse" id="mainNavbar">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item">
-            <RouterLink class="nav-link" to="/">Каталог</RouterLink>
-          </li>
-          <li class="nav-item">
-            <RouterLink class="nav-link" to="/cart">Корзина</RouterLink>
-          </li>
-          <li v-if="isAuthenticated" class="nav-item">
-            <RouterLink class="nav-link" to="/orders">Мои заказы</RouterLink>
-          </li>
-          <li v-if="isAuthenticated" class="nav-item">
-            <RouterLink class="nav-link" to="/profile">Профиль</RouterLink>
-          </li>
-          <li v-if="user?.role?.name === 'Менеджер'" class="nav-item">
-            <RouterLink class="nav-link" to="/manager">Панель менеджера</RouterLink>
-          </li>
-          <li
-            v-if="user?.role?.name === 'Менеджер' || user?.role?.name === 'Администратор'"
-            class="nav-item"
-          >
-            <RouterLink class="nav-link" to="/manager/reports">Отчётность</RouterLink>
-          </li>
-          <li v-if="user?.role?.name === 'Администратор'" class="nav-item">
-            <RouterLink class="nav-link" to="/admin/users">Управление пользователями</RouterLink>
-          </li>
-          <li v-if="user?.role?.name === 'Администратор'" class="nav-item">
-            <RouterLink class="nav-link" to="/admin/audit">Журнал аудита</RouterLink>
-          </li>
-          <li v-if="user?.role?.name === 'Администратор'" class="nav-item">
-            <RouterLink class="nav-link" to="/admin/reviews">Отзывы</RouterLink>
+          <li v-for="(link, index) in navigationLinks" :key="link.to" class="nav-item">
+            <RouterLink class="nav-link" :to="link.to">
+              {{ link.label }}
+              <span class="shortcut-hint" aria-hidden="true">Alt+{{ index + 1 }}</span>
+            </RouterLink>
           </li>
         </ul>
         <div class="d-flex align-items-center flex-wrap gap-2">
@@ -58,8 +34,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue';
-import { RouterLink, useRouter } from 'vue-router';
+import { computed, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue';
+import { NavigationFailureType, RouterLink, isNavigationFailure, useRouter } from 'vue-router';
 import { useAuthStore } from '../store/authStore';
 import LogoutConfirmModal from './LogoutConfirmModal.vue';
 import ThemeToggle from './ThemeToggle.vue';
@@ -70,6 +46,36 @@ const user = computed(() => authStore.user);
 const isAuthenticated = computed(() => authStore.isAuthenticated);
 
 const showModal = ref(false);
+
+const navigationLinks = computed(() => {
+  const links = [
+    { to: '/', label: 'Каталог' },
+    { to: '/cart', label: 'Корзина' },
+  ];
+
+  if (isAuthenticated.value) {
+    links.push({ to: '/orders', label: 'Мои заказы' });
+    links.push({ to: '/profile', label: 'Профиль' });
+  }
+
+  const roleName = user.value?.role?.name;
+
+  if (roleName === 'Менеджер') {
+    links.push({ to: '/manager', label: 'Панель менеджера' });
+  }
+
+  if (roleName === 'Менеджер' || roleName === 'Администратор') {
+    links.push({ to: '/manager/reports', label: 'Отчётность' });
+  }
+
+  if (roleName === 'Администратор') {
+    links.push({ to: '/admin/users', label: 'Управление пользователями' });
+    links.push({ to: '/admin/audit', label: 'Журнал аудита' });
+    links.push({ to: '/admin/reviews', label: 'Отзывы' });
+  }
+
+  return links;
+});
 
 const openModal = () => {
   showModal.value = true;
@@ -85,6 +91,80 @@ const handleLogout = async () => {
   await router.replace({ name: 'home', query: { message: 'Вы успешно вышли из аккаунта' } });
 };
 
+const shouldIgnoreShortcut = (event: KeyboardEvent) => {
+  const target = event.target as HTMLElement | null;
+  if (!target) {
+    return false;
+  }
+
+  const tagName = target.tagName;
+  const isFormField = ['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName);
+
+  return isFormField || target.isContentEditable;
+};
+
+const resolveShortcutIndex = (event: KeyboardEvent) => {
+  const { code, key } = event;
+
+  if (code.startsWith('Digit') || code.startsWith('Numpad')) {
+    const index = Number.parseInt(code.replace(/\D/g, ''), 10);
+
+    if (Number.isInteger(index)) {
+      return index === 0 ? 9 : index - 1;
+    }
+  }
+
+  if (key === '0') {
+    return 9;
+  }
+
+  const parsed = Number.parseInt(key, 10);
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed - 1;
+};
+
+const handleShortcut = (event: KeyboardEvent) => {
+  if (!event.altKey || event.repeat || shouldIgnoreShortcut(event)) {
+    return;
+  }
+
+  const shortcutIndex = resolveShortcutIndex(event);
+
+  if (shortcutIndex === null) {
+    return;
+  }
+
+  const link = navigationLinks.value[shortcutIndex];
+
+  if (!link) {
+    return;
+  }
+
+  event.preventDefault();
+
+  const currentPath = router.currentRoute.value.path;
+
+  if (currentPath !== link.to) {
+    router.push(link.to).catch((error) => {
+      if (!isNavigationFailure(error, NavigationFailureType.duplicated)) {
+        console.error('Navigation shortcut error', error);
+      }
+    });
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleShortcut);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleShortcut);
+});
+
 watchEffect(() => {
   console.info('Navbar reactive snapshot', {
     isAuthenticated: isAuthenticated.value,
@@ -92,3 +172,19 @@ watchEffect(() => {
   });
 });
 </script>
+
+<style scoped>
+.shortcut-hint {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.65;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 991.98px) {
+  .shortcut-hint {
+    display: none;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- build the navbar link list dynamically so roles only see the routes they can access
- wire up Alt+number shortcuts that follow the current link ordering and ignore focused form fields
- surface subtle shortcut hints next to each link and guard against duplicate navigation errors

## Testing
- npm run db:reset
- curl -s -X POST http://localhost:3000/auth/login -H "Content-Type: application/json" -d '{"email":"admin@shop.local","password":"admin123"}' | jq
- Playwright automation of Alt+2 navigation (screenshots before/after)


------
https://chatgpt.com/codex/tasks/task_e_68fb61c78ad48321a663c99afbae3c57