### PR TITLE
Fix overflow menu interactions in header

### DIFF
--- a/frontend/src/components/AppNavbar.vue
+++ b/frontend/src/components/AppNavbar.vue
@@ -318,6 +318,11 @@ watch(
   width: 100%;
 }
 
+.navbar {
+  position: relative;
+  z-index: 100;
+}
+
 .layout-container :deep(.navbar-brand) {
   white-space: nowrap;
 }
@@ -376,6 +381,7 @@ watch(
 
 .overflow-menu-wrapper {
   position: relative;
+  z-index: 20;
 }
 
 .overflow-toggle {
@@ -407,7 +413,7 @@ watch(
   position: absolute;
   right: 0;
   top: calc(100% + 0.5rem);
-  z-index: 10;
+  z-index: 100;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;


### PR DESCRIPTION
## Summary
- raise the navbar stacking context so the overflow dropdown renders above the main content
- bump the overflow menu wrapper and list z-index values to keep every entry clickable

## Testing
- npm run build (frontend)
- npm run build (backend)


------
https://chatgpt.com/codex/tasks/task_e_68fc060f17b48321b3570c00bc3b6d57