### PR TITLE
Fix product creation flow with size-based pricing

### DIFF
--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -10,6 +10,7 @@ import {
   Length,
   MaxLength,
   ValidateNested,
+  ValidateIf,
 } from 'class-validator';
 import { ProductSizeWithStockDto } from './product-size.dto';
 
@@ -33,10 +34,16 @@ export class CreateProductDto {
   @IsString({ message: 'Описание должно быть строкой' })
   description?: string;
 
-  @ApiProperty({ example: 2990, description: 'Цена товара' })
+  @ApiPropertyOptional({
+    example: 2990,
+    description:
+      'Цена товара (обязательна, если у товара отсутствуют размеры)',
+  })
+  @ValidateIf((dto) => !dto.sizes || dto.sizes.length === 0)
   @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Цена должна быть числом' })
   @IsPositive({ message: 'Цена должна быть больше нуля' })
-  price: number;
+  @IsOptional()
+  price?: number;
 
   @ApiProperty({ example: 'SLP-TS-002', description: 'Артикул товара' })
   @IsString({ message: 'Артикул должен быть строкой' })

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -461,22 +461,30 @@ export class ProductsService {
   }
 
   private determineBasePrice(
-    requestedPrice: number,
+    requestedPrice: number | undefined,
     sizes: NormalizedProductSize[],
   ): number {
-    if (!sizes.length) {
-      return requestedPrice;
+    if (sizes.length) {
+      const sizePrices = sizes
+        .map((size) => size.price)
+        .filter((price) => Number.isFinite(price) && price > 0);
+
+      if (sizePrices.length) {
+        return Math.min(...sizePrices);
+      }
     }
 
-    const sizePrices = sizes
-      .map((size) => size.price)
-      .filter((price) => Number.isFinite(price) && price > 0);
-
-    if (!sizePrices.length) {
-      return requestedPrice;
+    if (
+      requestedPrice === undefined ||
+      !Number.isFinite(requestedPrice) ||
+      requestedPrice <= 0
+    ) {
+      throw new BadRequestException(
+        'Для товара без размеров необходимо указать корректную цену',
+      );
     }
 
-    return Math.min(...sizePrices);
+    return requestedPrice;
   }
 
   private resolveBasePriceFromEntity(product: Product): number {

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -58,7 +58,7 @@ export interface UpdateProductPayload {
 export interface CreateProductPayload {
   title: string;
   description?: string;
-  price: number;
+  price?: number;
   sku: string;
   imageUrl?: string;
   categoryId: number;

--- a/frontend/src/pages/ManagerPage.vue
+++ b/frontend/src/pages/ManagerPage.vue
@@ -111,8 +111,12 @@
                   min="0"
                   step="0.01"
                   class="form-control"
-                  required
+                  :required="!isEditingProductWithSizes"
+                  :disabled="isEditingProductWithSizes"
                 />
+                <div v-if="isEditingProductWithSizes" class="form-text text-muted">
+                  Цена рассчитывается автоматически по размерам.
+                </div>
               </div>
               <div class="col-md-3">
                 <label class="form-label" for="productCategory">Категория</label>
@@ -442,9 +446,12 @@
               min="0"
               step="0.01"
               class="form-input"
-              required
-              :disabled="creatingProduct"
+              :required="!addProductHasConfiguredSizes"
+              :disabled="creatingProduct || addProductHasConfiguredSizes"
             />
+            <p v-if="addProductHasConfiguredSizes" class="form-field__hint">
+              Стоимость будет рассчитана по минимальной цене среди размеров.
+            </p>
           </div>
           <div class="form-grid__item">
             <label for="newProductCategory" class="form-field__label">Категория</label>
@@ -541,7 +548,7 @@
                 type="button"
                 class="dialog-button dialog-button--danger dialog-button--sm manager-sizes__remove"
                 @click="removeSizeRow(addProductForm.sizes, index)"
-                :disabled="creatingProduct || addProductForm.sizes.length <= 1"
+                :disabled="creatingProduct"
               >
                 Удалить
               </button>
@@ -722,7 +729,7 @@
 <script setup lang="ts">
 import { DialogTitle } from '@headlessui/vue';
 import { ClipboardDocumentListIcon, PlusCircleIcon, XMarkIcon } from '@heroicons/vue/24/outline';
-import { onMounted, reactive, ref } from 'vue';
+import { computed, onMounted, reactive, ref } from 'vue';
 import GlassModal from '../components/GlassModal.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import {
@@ -874,7 +881,7 @@ const showSuccess = (message: string) => {
 
 const toEditableSizes = (sizes: ProductDto['sizes']): EditableProductSize[] => {
   if (!sizes.length) {
-    return [{ id: null, size: '', price: '', stock: '' }];
+    return [];
   }
 
   return sizes.map((size) => ({
@@ -923,18 +930,24 @@ const buildSizePayload = (sizes: EditableProductSize[]): ProductSizePayload[] =>
   return payload;
 };
 
+const hasConfiguredSizes = (sizes: EditableProductSize[]): boolean =>
+  sizes.some((size) => size.size.trim().length > 0);
+
 const addSizeRow = (rows: EditableProductSize[]) => {
   rows.push({ id: null, size: '', price: '', stock: '' });
 };
 
 const removeSizeRow = (rows: EditableProductSize[], index: number) => {
-  if (rows.length <= 1) {
-    rows.splice(0, rows.length, { id: null, size: '', price: '', stock: '' });
-    return;
-  }
-
   rows.splice(index, 1);
 };
+
+const addProductHasConfiguredSizes = computed(() =>
+  hasConfiguredSizes(addProductForm.sizes),
+);
+
+const isEditingProductWithSizes = computed(() =>
+  (productForm.value ? hasConfiguredSizes(productForm.value.sizes) : false),
+);
 
 const getTotalStock = (product: ProductDto): number =>
   product.sizes.reduce((sum, size) => sum + size.stock, 0);
@@ -963,7 +976,7 @@ const resetAddProductForm = () => {
     sku: '',
     imageUrl: '',
     categoryId: '',
-    sizes: [{ id: null, size: '', price: '', stock: '' }],
+    sizes: [],
   });
 };
 
@@ -1095,12 +1108,7 @@ const cancelProductEdit = () => {
 };
 
 const saveNewProduct = async () => {
-  if (
-    !addProductForm.title ||
-    !addProductForm.sku ||
-    !addProductForm.price ||
-    !addProductForm.categoryId
-  ) {
+  if (!addProductForm.title || !addProductForm.sku || !addProductForm.categoryId) {
     return;
   }
 
@@ -1112,17 +1120,32 @@ const saveNewProduct = async () => {
     return;
   }
 
+  const hasSizes = sizePayload.length > 0;
+
+  if (!hasSizes) {
+    const basePrice = Number(addProductForm.price);
+    if (!addProductForm.price || !Number.isFinite(basePrice) || basePrice <= 0) {
+      showError('Укажите корректную цену для товара без размеров.');
+      return;
+    }
+  }
+
   try {
     creatingProduct.value = true;
     const payload: CreateProductPayload = {
       title: addProductForm.title,
       description: addProductForm.description ? addProductForm.description : undefined,
-      price: Number(addProductForm.price),
       sku: addProductForm.sku,
       imageUrl: addProductForm.imageUrl ? addProductForm.imageUrl : undefined,
       categoryId: Number(addProductForm.categoryId),
-      sizes: sizePayload.length ? sizePayload : undefined,
+      sizes: hasSizes ? sizePayload : undefined,
     };
+
+    if (!hasSizes) {
+      const basePrice = Number(addProductForm.price);
+      payload.price = Number(basePrice.toFixed(2));
+    }
+
     await createProduct(payload);
     products.value = await fetchProducts();
     showSuccess('Новый товар добавлен.');
@@ -1145,12 +1168,20 @@ const saveProduct = async () => {
     showError(error);
     return;
   }
+  const hasSizes = sizePayload.length > 0;
+
+  if (!hasSizes) {
+    const basePrice = Number(productForm.value.price);
+    if (!productForm.value.price || !Number.isFinite(basePrice) || basePrice <= 0) {
+      showError('Укажите корректную цену для товара без размеров.');
+      return;
+    }
+  }
   try {
     productSaving.value = true;
     const payload: UpdateProductPayload = {
       title: productForm.value.title,
       description: productForm.value.description || undefined,
-      price: Number(productForm.value.price),
       sku: productForm.value.sku,
       imageUrl: productForm.value.imageUrl || undefined,
       categoryId: productForm.value.categoryId
@@ -1158,6 +1189,11 @@ const saveProduct = async () => {
         : undefined,
       sizes: sizePayload,
     };
+
+    if (!hasSizes) {
+      const basePrice = Number(productForm.value.price);
+      payload.price = Number(basePrice.toFixed(2));
+    }
     await updateProduct(productForm.value.id, payload);
     await refreshProducts();
     productForm.value = null;
@@ -1383,6 +1419,12 @@ onMounted(() => {
 
 .manager-form-grid {
   gap: clamp(1rem, 2vw, 1.35rem);
+}
+
+.form-field__hint {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
 }
 
 .manager-sizes {


### PR DESCRIPTION
## Summary
- require a base price only for products without size pricing and derive the minimum size price otherwise
- ensure base price validation on the backend and make create product payloads handle optional price fields
- update the manager UI to disable the base price field when sizes are present, allow removing all size rows, and validate submissions accordingly

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68fdc5ddd7308321a94c5730db262b94