### PR TITLE
Fix product size pricing validation in manager tools

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -103,11 +103,11 @@ CREATE TABLE IF NOT EXISTS sizes (
 
 CREATE TABLE IF NOT EXISTS products (
     id SERIAL PRIMARY KEY,
-    title VARCHAR(200) NOT NULL,
+    title VARCHAR(200) NOT NULL CHECK (char_length(btrim(title)) >= 2),
     description TEXT,
     image_url TEXT,
-    price NUMERIC(10, 2) NOT NULL CHECK (price >= 0),
-    sku VARCHAR(100) NOT NULL UNIQUE,
+    price NUMERIC(10, 2) NOT NULL CHECK (price > 0),
+    sku VARCHAR(100) NOT NULL UNIQUE CHECK (char_length(btrim(sku)) >= 2),
     category_id INTEGER NOT NULL REFERENCES categories(id),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
@@ -130,8 +130,8 @@ CREATE TABLE IF NOT EXISTS product_images (
 CREATE TABLE IF NOT EXISTS product_sizes (
     id SERIAL PRIMARY KEY,
     product_id INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
-    size VARCHAR(20) NOT NULL,
-    price NUMERIC(10, 2) NOT NULL CHECK (price >= 0),
+    size VARCHAR(20) NOT NULL CHECK (char_length(btrim(size)) >= 1),
+    price NUMERIC(10, 2) NOT NULL CHECK (price > 0),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
     UNIQUE (product_id, size)

--- a/backend/src/modules/products/dto/create-product.dto.ts
+++ b/backend/src/modules/products/dto/create-product.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsArray,
   IsInt,
@@ -20,6 +20,7 @@ export class CreateProductDto {
     example: 'Футболка Slipknot Iowa',
     description: 'Название товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Название товара должно быть строкой' })
   @Length(2, 200, {
     message: 'Название товара должно содержать от 2 до 200 символов',
@@ -30,6 +31,7 @@ export class CreateProductDto {
     example: 'Чёрная футболка с логотипом Slipknot',
     description: 'Описание товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Описание должно быть строкой' })
   description?: string;
@@ -39,6 +41,7 @@ export class CreateProductDto {
     description:
       'Цена товара (обязательна, если у товара отсутствуют размеры)',
   })
+  @Type(() => Number)
   @ValidateIf((dto) => !dto.sizes || dto.sizes.length === 0)
   @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Цена должна быть числом' })
   @IsPositive({ message: 'Цена должна быть больше нуля' })
@@ -46,6 +49,7 @@ export class CreateProductDto {
   price?: number;
 
   @ApiProperty({ example: 'SLP-TS-002', description: 'Артикул товара' })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Артикул должен быть строкой' })
   @Length(2, 100, { message: 'Артикул должен содержать от 2 до 100 символов' })
   sku: string;
@@ -54,6 +58,7 @@ export class CreateProductDto {
     example: 'https://example.com/images/shirt.jpg',
     description: 'Ссылка на изображение товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Ссылка на изображение должна быть строкой' })
   @MaxLength(500, {
@@ -62,7 +67,9 @@ export class CreateProductDto {
   imageUrl?: string;
 
   @ApiProperty({ example: 3, description: 'Идентификатор категории' })
+  @Type(() => Number)
   @IsInt({ message: 'Идентификатор категории должен быть числом' })
+  @IsPositive({ message: 'Идентификатор категории должен быть больше нуля' })
   categoryId: number;
 
   @ApiPropertyOptional({

--- a/backend/src/modules/products/dto/product-size.dto.ts
+++ b/backend/src/modules/products/dto/product-size.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
 import {
   IsInt,
   IsNumber,
@@ -11,6 +12,7 @@ import {
 // dto describing size + stock payload for product creation/update
 export class ProductSizeWithStockDto {
   @ApiProperty({ example: 'L', description: 'Название размера' })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsString({ message: 'Название размера должно быть строкой' })
   @Length(1, 20, {
     message: 'Название размера должно содержать от 1 до 20 символов',
@@ -18,11 +20,13 @@ export class ProductSizeWithStockDto {
   size: string;
 
   @ApiProperty({ example: 3190, description: 'Цена для выбранного размера' })
+  @Type(() => Number)
   @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Цена должна быть числом' })
   @IsPositive({ message: 'Цена должна быть больше нуля' })
   price: number;
 
   @ApiProperty({ example: 15, description: 'Количество товара на складе' })
+  @Type(() => Number)
   @IsInt({ message: 'Количество должно быть целым числом' })
   @Min(0, { message: 'Количество не может быть отрицательным' })
   stock: number;

--- a/backend/src/modules/products/dto/update-product.dto.ts
+++ b/backend/src/modules/products/dto/update-product.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsArray,
   IsInt,
@@ -10,6 +10,7 @@ import {
   Length,
   MaxLength,
   ValidateNested,
+  ValidateIf,
 } from 'class-validator';
 import { ProductSizeWithStockDto } from './product-size.dto';
 
@@ -19,6 +20,7 @@ export class UpdateProductDto {
     example: 'Футболка Slipknot 1999',
     description: 'Название товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Название товара должно быть строкой' })
   @Length(2, 200, {
@@ -30,11 +32,16 @@ export class UpdateProductDto {
     example: 'Обновлённое описание товара',
     description: 'Описание товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Описание должно быть строкой' })
   description?: string;
 
   @ApiPropertyOptional({ example: 3190, description: 'Новая цена товара' })
+  @Type(() => Number)
+  @ValidateIf(
+    (dto) => Array.isArray(dto.sizes) && dto.sizes.length === 0,
+  )
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 }, { message: 'Цена должна быть числом' })
   @IsPositive({ message: 'Цена должна быть больше нуля' })
@@ -44,6 +51,7 @@ export class UpdateProductDto {
     example: 'SLP-TS-002-NEW',
     description: 'Артикул товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Артикул должен быть строкой' })
   @Length(2, 100, { message: 'Артикул должен содержать от 2 до 100 символов' })
@@ -53,6 +61,7 @@ export class UpdateProductDto {
     example: 'https://example.com/images/shirt-new.jpg',
     description: 'Ссылка на изображение товара',
   })
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   @IsOptional()
   @IsString({ message: 'Ссылка на изображение должна быть строкой' })
   @MaxLength(500, {
@@ -61,6 +70,7 @@ export class UpdateProductDto {
   imageUrl?: string;
 
   @ApiPropertyOptional({ example: 5, description: 'Идентификатор категории' })
+  @Type(() => Number)
   @IsOptional()
   @IsInt({ message: 'Идентификатор категории должен быть числом' })
   categoryId?: number;


### PR DESCRIPTION
## Summary
- trim and validate product creation/update DTOs so required fields and size-only pricing are enforced server-side
- require trimmed names and positive prices for product sizes and align the SQL schema with the updated constraints
- harden the manager product form to validate mandatory fields, prevent base price entry when sizes are configured, and derive payloads cleanly

## Testing
- npm run build (frontend)
- npm run build (backend)

------
https://chatgpt.com/codex/tasks/task_e_68fdd8a336008321b139da32c2e8da78