### PR TITLE
Fix product image URLs to use absolute paths

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -2,10 +2,29 @@ import axios from 'axios';
 
 export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
+
 export const http = axios.create({
   baseURL: API_URL,
   withCredentials: false,
 });
+
+export const resolveApiUrl = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(trimmed) || trimmed.startsWith('//')) {
+    return trimmed;
+  }
+
+  try {
+    return new URL(trimmed, API_URL).toString();
+  } catch {
+    return trimmed;
+  }
+};
 
 http.interceptors.request.use((config) => {
   const token = localStorage.getItem('accessToken');


### PR DESCRIPTION
## Summary
- derive a configurable public base URL for product media and normalize stored image paths on the backend
- return absolute product image URLs in API responses so new uploads render correctly in the catalog
- expose an HTTP helper to resolve relative API URLs on the frontend

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68ff3619cfa48321b0cdc12c4dd97dba